### PR TITLE
Prime.prime? and Integer#prime? from 1.9.1

### DIFF
--- a/lib/backports/1.9.1/prime.rb
+++ b/lib/backports/1.9.1/prime.rb
@@ -1,0 +1,58 @@
+# Standard in Ruby 1.9. See official documentation[http://ruby-doc.org/core-1.9/classes/Prime.html]
+class Prime
+  # Standard in Ruby 1.9. See official documentation[http://ruby-doc.org/core-1.9/classes/Prime/PseudoPrimeGenerator.html]
+  class PseudoPrimeGenerator
+    include Enumerable
+
+    def each(&block)
+      block_given? ? loop { block.call(succ) } : self.dup
+    end unless method_defined? :each
+  end
+
+  # Standard in Ruby 1.9. See official documentation[http://ruby-doc.org/core-1.9/classes/Prime/Generator23.html]
+  class Generator23 < PseudoPrimeGenerator
+    def initialize
+      @prime, @step = 1, nil
+      super
+    end unless method_defined? :initialize
+
+    def succ
+      loop do
+        if (@step)
+          @prime += @step
+          @step = 6 - @step
+        else
+          case @prime
+          when 1; @prime = 2
+          when 2; @prime = 3
+          when 3; @prime = 5; @step = 2
+          end
+        end
+        return @prime
+      end
+    end unless method_defined? :succ
+
+    alias_method :next,   :succ       unless method_defined? :next
+    alias_method :rewind, :initialize unless method_defined? :rewind
+  end
+
+  class << self
+    # Standard in Ruby 1.9. See official documentation[http://ruby-doc.org/core-1.9/classes/Prime.html]
+    def prime?(value, generator = Prime::Generator23.new)
+      value = -value if value < 0
+      return false   if value < 2
+      for num in generator
+        q, r = value.divmod num
+        return true  if q < num
+        return false if r == 0
+      end
+    end unless method_defined? :prime?
+  end
+end
+
+class Integer
+  # Standard in Ruby 1.9. See official documentation[http://ruby-doc.org/core-1.9/classes/Integer.html]
+  def prime?
+    Prime.prime?(self)
+  end unless method_defined? :prime?
+end


### PR DESCRIPTION
This is a backport of the most important functionality in 1.9's `Prime` standard library, namely the `Prime.prime?` method and the `Integer#prime?` method which is defined in terms of it. The implementation is a stripped and simplified version of that found in the `prime.rb` file in Ruby 1.9.1. Tested on 1.8.7 like so:

```
require 'backports/1.9.1'
p 1.upto(100).select(&:prime?)
#=> [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]
```

I could really use this in a pure-Ruby cryptography library I'm working on, so hopefully it could be merged even if this is, admittedly, part of a 1.9 standard library instead of the core 1.9 classes per se. (That is, in Ruby 1.9, one normally needs to do `require 'prime'` to get this functionality, but I don't know how to replicate that in Backports - might need to mess with the Ruby load path if fidelity on such level were required.)
