### PR TITLE
Fix File::NULL for ruby built with MinGW

### DIFF
--- a/lib/backports/1.9.3/file.rb
+++ b/lib/backports/1.9.3/file.rb
@@ -1,6 +1,6 @@
 class File
   NULL =  case RUBY_PLATFORM
-          when /mswin/i
+          when /mswin|mingw/i
             'NUL'
           when /amiga/i
             'NIL:'


### PR DESCRIPTION
Otherwise it produces a "File not found error" dumped to stderr when doing, for example:

```
`git rev-parse --git-dir 2>#{File::NULL}`
```

This patch, however, will not work on JRuby, because `RUBY_PLATFORM` is always "java".
I don't know why they chose that, but I guess the only right way is then `RbConfig::CONFIG['host_os']` (excluding parsing RUBY_DESCRIPTION). What do you think?
