### PR TITLE
add advice about requiring early to readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,6 +40,8 @@ To use:
   require 'rubygems'
   require 'backports'   # or a subset, see next section
 
+Note that you'll typically want to require backports early (or put it at the top of your Gemfile), as otherwise you may encounter 'already initialized constant' warnings and other (harmless but unnecessary) noise.
+
 Compatible with Ruby 1.8.6, 1.8.7, 1.9.1, 1.9.2, 1.9.3, JRuby and Rubinius.
 
 = Complete List of backports


### PR DESCRIPTION
If you do:

``` ruby
require 'prime'
require 'backports'
```

you get the following noise on stderr:

```
Prime::new is obsolete. use Prime::instance or class methods of Prime.
…/gems/backports-2.6.4/lib/backports/1.9.1/stdlib/prime.rb:411: warning: already initialized constant BITS_PER_ENTRY
…/gems/backports-2.6.4/lib/backports/1.9.1/stdlib/prime.rb:412: warning: already initialized constant NUMS_PER_ENTRY
…/gems/backports-2.6.4/lib/backports/1.9.1/stdlib/prime.rb:413: warning: already initialized constant ENTRIES_PER_TABLE
…/gems/backports-2.6.4/lib/backports/1.9.1/stdlib/prime.rb:414: warning: already initialized constant NUMS_PER_TABLE
…/gems/backports-2.6.4/lib/backports/1.9.1/stdlib/prime.rb:415: warning: already initialized constant FILLED_ENTRY
```

Not very surprising behavior in this reduced case, but I ran across it in a less obvious fashion when I required a gem that requires 'prime' before I required the gem I'm using that requires 'backports'.  Hopefully adding this to the Readme can help someone else figure out why they're getting these warnings a bit quicker than I did.
