### PR TITLE
Add tracepoint.rb to 2.0.0

### DIFF
--- a/lib/backports/2.0.0/tracepoint.rb
+++ b/lib/backports/2.0.0/tracepoint.rb
@@ -110,19 +110,31 @@ class TracePoint
     else
       previous_state = enabled?
       @enabled = false
-      self.class.tracepoints.delete self
+      self.class.tracepoints.delete(self.reset)
       self.class.switch!
       previous_state
     end
   end
 
-  attr_reader :event
+  def event
+    raise if disabled?
+    @event
+  end
 
-  attr_reader :path
+  def path
+    raise if disabled?
+    @path
+  end
 
-  attr_reader :lineno
+  def lineno
+    raise if disabled?
+    @lineno
+  end
 
-  attr_reader :binding
+  def binding
+    raise if disabled?
+    @binding
+  end
 
   # The previous binding.
   #
@@ -132,24 +144,29 @@ class TracePoint
   #       would agree to include in Ruby's API.
   #
   # Returns [Binding]
-  attr_reader :prior_binding
+  def prior_binding
+    raise if disabled?
+    @prior_binding
+  end
 
   # Alias for #prior_binding.
   #
   # Returns [Binding]
   def binding_of_caller
+    raise if disabled?
     @prior_binding
   end
 
   def self
-    @binding.self
+    binding.self
   end
 
   def defined_class
-    @binding.eval "#{self.class}"
+    binding.eval "#{self.class}"
   end
 
   def method_id
+    raise if disabled?
     @method
   end
 
@@ -180,6 +197,8 @@ class TracePoint
 
   def inspect
     return "#<TracePoint:disabled>" if disabled?
+    return "#<TracePoint:enabled>" unless event
+
     case event
     when :line
 		  if method_id.nil?
@@ -211,6 +230,17 @@ protected
     @klass   = klass
     @binding = bind || TOPLEVEL_BINDING  # TODO: Correct ?
     @prior_binding = prebind || TOPLEVEL_BINDING  # TODO: or leave nil ?
+  end
+
+  def reset
+    @event   = nil
+    @path    = nil
+    @lineno  = nil
+    @method  = nil
+    @klass   = nil
+    @binding = nil
+    @prior_binding = nil
+    return self
   end
 end
 

--- a/lib/backports/2.0.0/tracepoint.rb
+++ b/lib/backports/2.0.0/tracepoint.rb
@@ -1,0 +1,193 @@
+class TracePoint
+
+  def self.trace(*events, &proc)
+    trace = new(*events, &proc)
+    trace.enable
+  end
+
+  def self.tracepoints #:nodoc:
+    @tracepoints ||= []
+  end
+
+  def self.switch! #:nodoc:
+    if @tracepoints.empty?
+      set_trace_func(nil)
+    else
+      bb_stack = []
+      fn = lambda do |e, f, l, m, b, k|
+        # TODO: This condition likely needs to be refined. The point is to prevent
+        #       tracing of the code that does the tracing itself, which a) no one
+        #       is interested in and b) prevents possbile infinite recursions.
+        unless $__trace__ or k === TracePoint or (k == Kernel && m == :set_trace_func)
+          $__trace__ = [e, f, l, m, b, k]
+          #(p e, f, l, m, b, k, bb_stack; puts "---") if $DEBUG
+          if ['call','c-call','b-call','class'].include?(e)
+            bb_stack << b
+          elsif ['return','c-return','b-return','end'].include?(e)
+            bb = bb_stack.pop
+          end
+          b = bb if ! b    # this sucks!
+          @tracepoints.each do |tp|
+            tp.send(:call_with, e, f, l, m, k, b, bb)
+          end
+          $__trace__ = nil
+        end
+      end
+      set_trace_func(fn)
+    end
+  end
+
+  def initialize(*events, &proc)
+    @events = events
+    @proc = proc || raise(ArgumentError, "trace procedure required")
+  end
+
+  def enabled?
+    @enabled
+  end
+
+  def enable
+    if block_given? && !enabled?
+      enable
+      result = yield
+      disable
+      result
+    else
+      previous_state = enabled?
+      @enabled = true
+      self.class.tracepoints << self
+      self.class.switch!
+      previous_state
+    end
+  end
+
+  def disable
+    if block_given? && enabled?
+      disable
+      result = yield
+      enable
+      result
+    else
+      previous_state = enabled?
+      @enabled = false
+      self.class.tracepoints.delete self
+      self.class.switch!
+      previous_state
+    end
+  end
+
+  attr_reader :event
+
+  attr_reader :path
+
+  attr_reader :lineno
+
+  attr_reader :binding
+
+  # The previous binding.
+  #
+  # Note: This is the only *extra* feature that is not currently
+  #       part of Ruby 2.0's implementation. It has proven useful
+  #       so it's been kept. It would be nice if ko1 (Koichi Sasada)
+  #       would agree to include in Ruby's API.
+  #
+  # Returns [Binding]
+  attr_reader :prior_binding
+
+  # Alias for #prior_binding.
+  #
+  # Returns [Binding]
+  def binding_of_caller
+    @prior_binding
+  end
+
+  def self
+    @binding.self
+  end
+
+  def defined_class
+    binding.eval{ self.class }
+  end
+
+  def method_id
+    @method
+  end
+
+  # TODO: How to get raised exception?
+  def raised_exception
+    raise NotImplementedError, "Please constribute a patch if you know how to fix."
+
+    case event
+    when :raise
+      @klass
+    end
+  end
+
+  # TODO: How to get the return value?
+  def return_value
+    raise NotImplementedError, "Please constribute a patch if you know how to fix."
+
+    case event
+    when :return, :c_return, :b_return
+      self
+    end
+  end
+
+  #--
+  # TODO: Ruby's code also had `RUBY_EVENT_SPECIFIED_LINE` with :line,
+  #       but I have not idea what that is.
+  #++
+
+  def inspect
+    case event
+    when :line
+		  if method_id.nil?
+        "#<TracePoint:%s@%s:%d>" % [event, path, lineno]
+      else
+        "#<TracePoint:%s@%s:%d in `%s'>" % [event, path, lineno, method_id]
+      end
+    when :call, :c_call, :return, :c_return
+      "#<TracePoint:%s `%s'@%s:%d>" % [event, method_id, path, lineno]
+    when :thread_begin, :thread_end
+	    "#<TracePoint:%s %s>" % [event, self]
+    else
+      "#<TracePoint:%s@%s:%d>" % [event, path, lineno]
+    end
+  end
+
+protected
+
+  def call_with(event, file, line, method, klass, bind, prebind=nil) #:nodoc:
+    set(event, file, line, method, klass, bind, prebind)
+    @proc.call(self)
+  end
+
+  def set(event, path, line, method, klass, bind, prebind=nil)  #:nodoc:
+    @event   = event.to_sym
+    @path    = path
+    @lineno  = line
+    @method  = method
+    @klass   = klass
+    @binding = bind || TOPLEVEL_BINDING  # TODO: Correct ?
+    @prior_binding = prebind || TOPLEVEL_BINDING  # TODO: or leave nil ?
+  end
+end
+
+
+class Binding
+
+  unless method_defined?(:eval) # 1.8.7+
+    def eval(code)
+      Kernel.eval(code, self)
+    end
+  end
+
+  unless method_defined?(:self) # 1.9+ ?
+    def self()
+      @_self ||= eval("self")
+    end
+  end
+
+end
+
+# Copyright (c) 2005,2013 Thomas Sawyer (BSD-2-Clause License)

--- a/test/envutil.rb
+++ b/test/envutil.rb
@@ -1,0 +1,364 @@
+# -*- coding: us-ascii -*-
+require "open3"
+require "timeout"
+
+module EnvUtil
+  def rubybin
+    unless ENV["RUBYOPT"]
+
+    end
+    if ruby = ENV["RUBY"]
+      return ruby
+    end
+    ruby = "ruby"
+    rubyexe = ruby+".exe"
+    3.times do
+      if File.exist? ruby and File.executable? ruby and !File.directory? ruby
+        return File.expand_path(ruby)
+      end
+      if File.exist? rubyexe and File.executable? rubyexe
+        return File.expand_path(rubyexe)
+      end
+      ruby = File.join("..", ruby)
+    end
+    if defined?(RbConfig.ruby)
+      RbConfig.ruby
+    else
+      "ruby"
+    end
+  end
+  module_function :rubybin
+
+  LANG_ENVS = %w"LANG LC_ALL LC_CTYPE"
+
+  def invoke_ruby(args, stdin_data="", capture_stdout=false, capture_stderr=false, opt={})
+    in_c, in_p = IO.pipe
+    out_p, out_c = IO.pipe if capture_stdout
+    err_p, err_c = IO.pipe if capture_stderr && capture_stderr != :merge_to_stdout
+    opt = opt.dup
+    opt[:in] = in_c
+    opt[:out] = out_c if capture_stdout
+    opt[:err] = capture_stderr == :merge_to_stdout ? out_c : err_c if capture_stderr
+    if enc = opt.delete(:encoding)
+      out_p.set_encoding(enc) if out_p
+      err_p.set_encoding(enc) if err_p
+    end
+    timeout = opt.delete(:timeout) || 10
+    reprieve = opt.delete(:reprieve) || 1
+    c = "C"
+    child_env = {}
+    LANG_ENVS.each {|lc| child_env[lc] = c}
+    if Array === args and Hash === args.first
+      child_env.update(args.shift)
+    end
+    args = [args] if args.kind_of?(String)
+    pid = spawn(child_env, EnvUtil.rubybin, *args, opt)
+    in_c.close
+    out_c.close if capture_stdout
+    err_c.close if capture_stderr && capture_stderr != :merge_to_stdout
+    if block_given?
+      return yield in_p, out_p, err_p, pid
+    else
+      th_stdout = Thread.new { out_p.read } if capture_stdout
+      th_stderr = Thread.new { err_p.read } if capture_stderr && capture_stderr != :merge_to_stdout
+      in_p.write stdin_data.to_str
+      in_p.close
+      if (!th_stdout || th_stdout.join(timeout)) && (!th_stderr || th_stderr.join(timeout))
+        stdout = th_stdout.value if capture_stdout
+        stderr = th_stderr.value if capture_stderr && capture_stderr != :merge_to_stdout
+      else
+        signal = /mswin|mingw/ =~ RUBY_PLATFORM ? :KILL : :TERM
+        begin
+          Process.kill signal, pid
+        rescue Errno::ESRCH
+          break
+        else
+        end until signal == :KILL or (sleep reprieve; signal = :KILL; false)
+        raise Timeout::Error
+      end
+      out_p.close if capture_stdout
+      err_p.close if capture_stderr && capture_stderr != :merge_to_stdout
+      Process.wait pid
+      status = $?
+      return stdout, stderr, status
+    end
+  ensure
+    [th_stdout, th_stderr].each do |th|
+      th.kill if th
+    end
+    [in_c, in_p, out_c, out_p, err_c, err_p].each do |io|
+      io.close if io && !io.closed?
+    end
+    [th_stdout, th_stderr].each do |th|
+      th.join if th
+    end
+  end
+  module_function :invoke_ruby
+
+  alias rubyexec invoke_ruby
+  class << self
+    alias rubyexec invoke_ruby
+  end
+
+  def verbose_warning
+    class << (stderr = "")
+      alias write <<
+    end
+    stderr, $stderr, verbose, $VERBOSE = $stderr, stderr, $VERBOSE, true
+    yield stderr
+    return $stderr
+  ensure
+    stderr, $stderr, $VERBOSE = $stderr, stderr, verbose
+  end
+  module_function :verbose_warning
+
+  def suppress_warning
+    verbose, $VERBOSE = $VERBOSE, nil
+    yield
+  ensure
+    $VERBOSE = verbose
+  end
+  module_function :suppress_warning
+
+  def under_gc_stress
+    stress, GC.stress = GC.stress, true
+    yield
+  ensure
+    GC.stress = stress
+  end
+  module_function :under_gc_stress
+end
+
+module Test
+  module Unit
+    module Assertions
+      public
+      def assert_valid_syntax(code, fname = caller_locations(1, 1)[0], mesg = fname.to_s)
+        code = code.dup.force_encoding("ascii-8bit")
+        code.sub!(/\A(?:\xef\xbb\xbf)?(\s*\#.*$)*(\n)?/n) {
+          "#$&#{"\n" if $1 && !$2}BEGIN{throw tag, :ok}\n"
+        }
+        code.force_encoding("us-ascii")
+        verbose, $VERBOSE = $VERBOSE, nil
+        yield if defined?(yield)
+        case
+        when Array === fname
+          fname, line = *fname
+        when defined?(fname.path) && defined?(fname.lineno)
+          fname, line = fname.path, fname.lineno
+        else
+          line = 0
+        end
+        assert_nothing_raised(SyntaxError, mesg) do
+          assert_equal(:ok, catch {|tag| eval(code, binding, fname, line)}, mesg)
+        end
+      ensure
+        $VERBOSE = verbose
+      end
+
+      def assert_syntax_error(code, error, fname = caller_locations(1, 1)[0], mesg = fname.to_s)
+        code = code.dup.force_encoding("ascii-8bit")
+        code.sub!(/\A(?:\xef\xbb\xbf)?(\s*\#.*$)*(\n)?/n) {
+          "#$&#{"\n" if $1 && !$2}BEGIN{throw tag, :ng}\n"
+        }
+        code.force_encoding("us-ascii")
+        verbose, $VERBOSE = $VERBOSE, nil
+        yield if defined?(yield)
+        case
+        when Array === fname
+          fname, line = *fname
+        when defined?(fname.path) && defined?(fname.lineno)
+          fname, line = fname.path, fname.lineno
+        else
+          line = 0
+        end
+        e = assert_raise(SyntaxError, mesg) do
+          catch {|tag| eval(code, binding, fname, line)}
+        end
+        assert_match(error, e.message, mesg)
+      ensure
+        $VERBOSE = verbose
+      end
+
+      def assert_normal_exit(testsrc, message = '', opt = {})
+        assert_valid_syntax(testsrc, caller_locations(1, 1)[0])
+        if opt.include?(:child_env)
+          opt = opt.dup
+          child_env = [opt.delete(:child_env)] || []
+        else
+          child_env = []
+        end
+        out, _, status = EnvUtil.invoke_ruby(child_env + %W'-W0', testsrc, true, :merge_to_stdout, opt)
+        assert !status.signaled?, FailDesc[status, message, out]
+      end
+
+      FailDesc = proc do |status, message = "", out = ""|
+        pid = status.pid
+        faildesc = proc do
+          signo = status.termsig
+          signame = Signal.list.invert[signo]
+          sigdesc = "signal #{signo}"
+          if signame
+            sigdesc = "SIG#{signame} (#{sigdesc})"
+          end
+          if status.coredump?
+            sigdesc << " (core dumped)"
+          end
+          full_message = ''
+          if message and !message.empty?
+            full_message << message << "\n"
+          end
+          full_message << "pid #{pid} killed by #{sigdesc}"
+          if out and !out.empty?
+            full_message << "\n#{out.gsub(/^/, '| ')}"
+            full_message << "\n" if /\n\z/ !~ full_message
+          end
+          full_message
+        end
+        faildesc
+      end
+
+      def assert_in_out_err(args, test_stdin = "", test_stdout = [], test_stderr = [], message = nil, opt={})
+        stdout, stderr, status = EnvUtil.invoke_ruby(args, test_stdin, true, true, opt)
+        if block_given?
+          raise "test_stdout ignored, use block only or without block" if test_stdout != []
+          raise "test_stderr ignored, use block only or without block" if test_stderr != []
+          yield(stdout.lines.map {|l| l.chomp }, stderr.lines.map {|l| l.chomp }, status)
+        else
+          errs = []
+          [[test_stdout, stdout], [test_stderr, stderr]].each do |exp, act|
+            begin
+              if exp.is_a?(Regexp)
+                assert_match(exp, act, message)
+              else
+                assert_equal(exp, act.lines.map {|l| l.chomp }, message)
+              end
+            rescue MiniTest::Assertion => e
+              errs << e.message
+              message = nil
+            end
+          end
+          raise MiniTest::Assertion, errs.join("\n---\n") unless errs.empty?
+          status
+        end
+      end
+
+      def assert_ruby_status(args, test_stdin="", message=nil, opt={})
+        _, _, status = EnvUtil.invoke_ruby(args, test_stdin, false, false, opt)
+        m = message ? "#{message} (#{status.inspect})" : "ruby exit status is not success: #{status.inspect}"
+        assert(status.success?, m)
+      end
+
+      ABORT_SIGNALS = Signal.list.values_at(*%w"ILL ABRT BUS SEGV")
+
+      def assert_separately(args, file = nil, line = nil, src = nil, opt={})
+        unless file and line
+          loc, = caller_locations(1,1)
+          file ||= loc.path
+          line ||= loc.lineno
+        end
+        src = <<eom
+  require 'test/unit';include Test::Unit::Assertions;begin;#{src}
+  ensure
+    puts [Marshal.dump($!)].pack('m'), "assertions=\#{self._assertions}"
+  end
+eom
+        stdout, stderr, status = EnvUtil.invoke_ruby(args, src, true, true, opt)
+        abort = status.coredump? || (status.signaled? && ABORT_SIGNALS.include?(status.termsig))
+        assert(!abort, FailDesc[status, stderr])
+        self._assertions += stdout[/^assertions=(\d+)/, 1].to_i
+        res = Marshal.load(stdout.unpack("m")[0])
+        return unless res
+        res.backtrace.each do |l|
+          l.sub!(/\A-:(\d+)/){"#{file}:#{line + $1.to_i}"}
+        end
+        raise res
+      end
+
+      def assert_warning(pat, message = nil)
+        stderr = EnvUtil.verbose_warning { yield }
+        message = ' "' + message + '"' if message
+        msg = proc {"warning message #{stderr.inspect} is expected to match #{pat.inspect}#{message}"}
+        assert(pat === stderr, msg)
+      end
+
+      def assert_warn(*args)
+        assert_warning(*args) {$VERBOSE = false; yield}
+      end
+
+=begin
+      def assert_no_memory_leak(args, prepare, code, message=nil, limit: 1.5)
+        token = "\e[7;1m#{$$.to_s}:#{Time.now.strftime('%s.%L')}:#{rand(0x10000).to_s(16)}:\e[m"
+        token_dump = token.dump
+        token_re = Regexp.quote(token)
+        args = [
+          "--disable=gems",
+          "-r", File.expand_path("../memory_status", __FILE__),
+          *args,
+          "-v", "-",
+        ]
+        cmd = [
+          'END {STDERR.puts '"#{token_dump}"'"FINAL=#{Memory::Status.new.size}"}',
+          prepare,
+          'STDERR.puts('"#{token_dump}"'"START=#{$initial_size = Memory::Status.new.size}")',
+          code,
+        ].join("\n")
+        _, err, status = EnvUtil.invoke_ruby(args, cmd, true, true)
+        before = err.sub!(/^#{token_re}START=(\d+)\n/, '') && $1.to_i
+        after = err.sub!(/^#{token_re}FINAL=(\d+)\n/, '') && $1.to_i
+        assert_equal([true, ""], [status.success?, err], message)
+        assert_operator(after.fdiv(before), :<, limit, message)
+      end
+=end
+
+      def assert_is_minus_zero(f)
+        assert(1.0/f == -Float::INFINITY, "#{f} is not -0.0")
+      end
+
+      def assert_file
+        AssertFile
+      end
+
+      class << (AssertFile = Struct.new(:failure_message).new)
+        include Assertions
+        def assert_file_predicate(predicate, *args)
+          if /\Anot_/ =~ predicate
+            predicate = $'
+            neg = " not"
+          end
+          result = File.__send__(predicate, *args)
+          result = !result if neg
+          mesg = "Expected file " << args.shift.inspect
+          mesg << mu_pp(args) unless args.empty?
+          mesg << "#{neg} to be #{predicate}"
+          mesg << " #{failure_message}" if failure_message
+          assert(result, mesg)
+        end
+        alias method_missing assert_file_predicate
+
+        def for(message)
+          clone.tap {|a| a.failure_message = message}
+        end
+      end
+    end
+  end
+end
+
+begin
+  require 'rbconfig'
+rescue LoadError
+else
+  module RbConfig
+    @ruby = EnvUtil.rubybin
+    class << self
+      undef ruby if method_defined?(:ruby)
+      attr_reader :ruby
+    end
+    dir = File.dirname(ruby)
+    name = File.basename(ruby, CONFIG['EXEEXT'])
+    CONFIG['bindir'] = dir
+    CONFIG['ruby_install_name'] = name
+    CONFIG['RUBY_INSTALL_NAME'] = name
+    Gem::ConfigMap[:bindir] = dir if defined?(Gem::ConfigMap)
+  end
+end

--- a/test/test_tracepoint.rb
+++ b/test/test_tracepoint.rb
@@ -1,0 +1,1025 @@
+require 'test/unit'
+require_relative 'envutil'
+require 'backports/2.0.0/tracepoint'
+
+class TestSetTraceFunc < Test::Unit::TestCase
+  def setup
+    @original_compile_option = RubyVM::InstructionSequence.compile_option
+    RubyVM::InstructionSequence.compile_option = {
+      :trace_instruction => true,
+      :specialized_instruction => false
+    }
+  end
+
+  def teardown
+    set_trace_func(nil)
+    RubyVM::InstructionSequence.compile_option = @original_compile_option
+  end
+
+  def test_c_call
+    events = []
+    name = "#{self.class}\##{__method__}"
+    eval <<-EOF.gsub(/^.*?: /, ""), nil, name
+     1: set_trace_func(Proc.new { |event, file, lineno, mid, binding, klass|
+     2:   events << [event, lineno, mid, klass] if file == name
+     3: })
+     4: x = 1 + 1
+     5: set_trace_func(nil)
+    EOF
+    #assert_equal(["c-return", 1, :set_trace_func, Kernel],
+    #             events.shift)
+    assert_equal(["c-return", 3, :set_trace_func, Kernel],
+                 events.shift)
+    assert_equal(["line", 4, __method__, self.class],
+                 events.shift)
+    assert_equal(["c-call", 4, :+, Fixnum],
+                 events.shift)
+    assert_equal(["c-return", 4, :+, Fixnum],
+                 events.shift)
+    assert_equal(["line", 5, __method__, self.class],
+                 events.shift)
+    assert_equal(["c-call", 5, :set_trace_func, Kernel],
+                 events.shift)
+    assert_equal([], events)
+  end
+
+  def test_call
+    events = []
+    name = "#{self.class}\##{__method__}"
+    eval <<-EOF.gsub(/^.*?: /, ""), nil, name
+     1: set_trace_func(Proc.new { |event, file, lineno, mid, binding, klass|
+     2:   events << [event, lineno, mid, klass] if file == name
+     3: })
+     4: def add(x, y)
+     5:   x + y
+     6: end
+     7: x = add(1, 1)
+     8: set_trace_func(nil)
+    EOF
+    #assert_equal(["c-return", 1, :set_trace_func, Kernel],
+    #             events.shift)
+    assert_equal(["c-return", 3, :set_trace_func, Kernel],
+                 events.shift)
+    assert_equal(["line", 4, __method__, self.class],
+                 events.shift)
+    assert_equal(["c-call", 4, :method_added, self.class],
+                 events.shift)
+    assert_equal(["c-return", 4, :method_added, self.class],
+                 events.shift)
+    assert_equal(["line", 7, __method__, self.class],
+                 events.shift)
+    assert_equal(["call", 4, :add, self.class],
+                 events.shift)
+    assert_equal(["line", 5, :add, self.class],
+                 events.shift)
+    assert_equal(["c-call", 5, :+, Fixnum],
+                 events.shift)
+    assert_equal(["c-return", 5, :+, Fixnum],
+                 events.shift)
+    assert_equal(["return", 6, :add, self.class],
+                 events.shift)
+    assert_equal(["line", 8, __method__, self.class],
+                 events.shift)
+    assert_equal(["c-call", 8, :set_trace_func, Kernel],
+                 events.shift)
+    assert_equal([], events)
+  end
+
+  def test_class
+    events = []
+    name = "#{self.class}\##{__method__}"
+    eval <<-EOF.gsub(/^.*?: /, ""), nil, name
+     1: set_trace_func(Proc.new { |event, file, lineno, mid, binding, klass|
+     2:   events << [event, lineno, mid, klass] if file == name
+     3: })
+     4: class Foo
+     5:   def bar
+     6:   end
+     7: end
+     8: x = Foo.new.bar
+     9: set_trace_func(nil)
+    EOF
+    #assert_equal(["c-return", 1, :set_trace_func, Kernel],
+    #             events.shift)
+    assert_equal(["c-return", 3, :set_trace_func, Kernel],
+                 events.shift)
+    assert_equal(["line", 4, __method__, self.class],
+                 events.shift)
+    assert_equal(["c-call", 4, :inherited, Class],
+                 events.shift)
+    assert_equal(["c-return", 4, :inherited, Class],
+                 events.shift)
+    assert_equal(["class", 4, nil, nil],
+                 events.shift)
+    assert_equal(["line", 5, nil, nil],
+                 events.shift)
+    assert_equal(["c-call", 5, :method_added, Module],
+                 events.shift)
+    assert_equal(["c-return", 5, :method_added, Module],
+                 events.shift)
+    assert_equal(["end", 7, nil, nil],
+                 events.shift)
+    assert_equal(["line", 8, __method__, self.class],
+                 events.shift)
+    assert_equal(["c-call", 8, :new, Class],
+                 events.shift)
+    assert_equal(["c-call", 8, :initialize, BasicObject],
+                 events.shift)
+    assert_equal(["c-return", 8, :initialize, BasicObject],
+                 events.shift)
+    assert_equal(["c-return", 8, :new, Class],
+                 events.shift)
+    assert_equal(["call", 5, :bar, Foo],
+                 events.shift)
+    assert_equal(["return", 6, :bar, Foo],
+                 events.shift)
+    assert_equal(["line", 9, __method__, self.class],
+                 events.shift)
+    assert_equal(["c-call", 9, :set_trace_func, Kernel],
+                 events.shift)
+    assert_equal([], events)
+  end
+
+  def test_return # [ruby-dev:38701]
+    events = []
+    name = "#{self.class}\##{__method__}"
+    eval <<-EOF.gsub(/^.*?: /, ""), nil, name
+     1: set_trace_func(Proc.new { |event, file, lineno, mid, binding, klass|
+     2:   events << [event, lineno, mid, klass] if file == name
+     3: })
+     4: def meth_return(a)
+     5:   return if a
+     6:   return
+     7: end
+     8: meth_return(true)
+     9: meth_return(false)
+    10: set_trace_func(nil)
+    EOF
+    #assert_equal(["c-return", 1, :set_trace_func, Kernel],
+    #             events.shift)
+    assert_equal(["c-return", 3, :set_trace_func, Kernel],
+                 events.shift)
+    assert_equal(["line", 4, __method__, self.class],
+                 events.shift)
+    assert_equal(["c-call", 4, :method_added, self.class],
+                 events.shift)
+    assert_equal(["c-return", 4, :method_added, self.class],
+                 events.shift)
+    assert_equal(["line", 8, __method__, self.class],
+                 events.shift)
+    assert_equal(["call", 4, :meth_return, self.class],
+                 events.shift)
+    assert_equal(["line", 5, :meth_return, self.class],
+                 events.shift)
+    assert_equal(["return", 5, :meth_return, self.class],
+                 events.shift)
+    assert_equal(["line", 9, :test_return, self.class],
+                 events.shift)
+    assert_equal(["call", 4, :meth_return, self.class],
+                 events.shift)
+    assert_equal(["line", 5, :meth_return, self.class],
+                 events.shift)
+    assert_equal(["return", 7, :meth_return, self.class],
+                 events.shift)
+    assert_equal(["line", 10, :test_return, self.class],
+                 events.shift)
+    assert_equal(["c-call", 10, :set_trace_func, Kernel],
+                 events.shift)
+    assert_equal([], events)
+  end
+
+  def test_return2 # [ruby-core:24463]
+    events = []
+    name = "#{self.class}\##{__method__}"
+    eval <<-EOF.gsub(/^.*?: /, ""), nil, name
+     1: set_trace_func(Proc.new { |event, file, lineno, mid, binding, klass|
+     2:   events << [event, lineno, mid, klass] if file == name
+     3: })
+     4: def meth_return2
+     5:   a = 5
+     6:   return a
+     7: end
+     8: meth_return2
+     9: set_trace_func(nil)
+    EOF
+    #assert_equal(["c-return", 1, :set_trace_func, Kernel],
+    #             events.shift)
+    assert_equal(["c-return", 3, :set_trace_func, Kernel],
+                 events.shift)
+    assert_equal(["line", 4, __method__, self.class],
+                 events.shift)
+    assert_equal(["c-call", 4, :method_added, self.class],
+                 events.shift)
+    assert_equal(["c-return", 4, :method_added, self.class],
+                 events.shift)
+    assert_equal(["line", 8, __method__, self.class],
+                 events.shift)
+    assert_equal(["call", 4, :meth_return2, self.class],
+                 events.shift)
+    assert_equal(["line", 5, :meth_return2, self.class],
+                 events.shift)
+    assert_equal(["line", 6, :meth_return2, self.class],
+                 events.shift)
+    assert_equal(["return", 7, :meth_return2, self.class],
+                 events.shift)
+    assert_equal(["line", 9, :test_return2, self.class],
+                 events.shift)
+    assert_equal(["c-call", 9, :set_trace_func, Kernel],
+                 events.shift)
+    assert_equal([], events)
+  end
+
+  def test_raise
+    events = []
+    name = "#{self.class}\##{__method__}"
+    eval <<-EOF.gsub(/^.*?: /, ""), nil, name
+     1: set_trace_func(Proc.new { |event, file, lineno, mid, binding, klass|
+     2:   events << [event, lineno, mid, klass] if file == name
+     3: })
+     4: begin
+     5:   raise TypeError, "error"
+     6: rescue TypeError
+     7: end
+     8: set_trace_func(nil)
+    EOF
+    #assert_equal(["c-return", 1, :set_trace_func, Kernel],
+    #             events.shift)
+    assert_equal(["c-return", 3, :set_trace_func, Kernel],
+                 events.shift)
+    assert_equal(["line", 4, __method__, self.class],
+                 events.shift)
+    assert_equal(["line", 5, __method__, self.class],
+                 events.shift)
+    assert_equal(["c-call", 5, :raise, Kernel],
+                 events.shift)
+    assert_equal(["c-call", 5, :exception, Exception],
+                 events.shift)
+    assert_equal(["c-call", 5, :initialize, Exception],
+                 events.shift)
+    assert_equal(["c-return", 5, :initialize, Exception],
+                 events.shift)
+    assert_equal(["c-return", 5, :exception, Exception],
+                 events.shift)
+    assert_equal(["c-call", 5, :backtrace, Exception],
+                 events.shift)
+    assert_equal(["c-return", 5, :backtrace, Exception],
+                 events.shift)
+    assert_equal(["raise", 5, :test_raise, TestSetTraceFunc],
+                 events.shift)
+    assert_equal(["c-return", 5, :raise, Kernel],
+                 events.shift)
+    assert_equal(["c-call", 6, :===, Module],
+                 events.shift)
+    assert_equal(["c-return", 6, :===, Module],
+                 events.shift)
+    assert_equal(["line", 8, __method__, self.class],
+                 events.shift)
+    assert_equal(["c-call", 8, :set_trace_func, Kernel],
+                 events.shift)
+    assert_equal([], events)
+  end
+
+  def test_break # [ruby-core:27606] [Bug #2610]
+    events = []
+    name = "#{self.class}\##{__method__}"
+    eval <<-EOF.gsub(/^.*?: /, ""), nil, name
+     1: set_trace_func(Proc.new { |event, file, lineno, mid, binding, klass|
+     2:   events << [event, lineno, mid, klass] if file == name
+     3: })
+     4: [1,2,3].any? {|n| n}
+     8: set_trace_func(nil)
+    EOF
+
+    #[["c-return", 1, :set_trace_func, Kernel],
+    [["c-return", 3, :set_trace_func, Kernel],
+     ["line", 4, __method__, self.class],
+     ["c-call", 4, :any?, Enumerable],
+     ["c-call", 4, :each, Array],
+     ["line", 4, __method__, self.class],
+     ["c-return", 4, :each, Array],
+     ["c-return", 4, :any?, Enumerable],
+     ["line", 5, __method__, self.class],
+     ["c-call", 5, :set_trace_func, Kernel]].each{|e|
+      assert_equal(e, events.shift)
+    }
+  end
+
+  def test_invalid_proc
+      assert_raise(TypeError) { set_trace_func(1) }
+  end
+
+  def test_raise_in_trace
+    set_trace_func proc {raise rescue nil}
+    assert_equal(42, (raise rescue 42), '[ruby-core:24118]')
+  end
+
+  def test_thread_trace
+    events = {:set => [], :add => []}
+    prc = Proc.new { |event, file, lineno, mid, binding, klass|
+      events[:set] << [event, lineno, mid, klass, :set]
+    }
+    prc = prc # suppress warning
+    prc2 = Proc.new { |event, file, lineno, mid, binding, klass|
+      events[:add] << [event, lineno, mid, klass, :add]
+    }
+    prc2 = prc2 # suppress warning
+
+    th = Thread.new do
+      th = Thread.current
+      name = "#{self.class}\##{__method__}"
+      eval <<-EOF.gsub(/^.*?: /, ""), nil, name
+       1: th.set_trace_func(prc)
+       2: th.add_trace_func(prc2)
+       3: class ThreadTraceInnerClass
+       4:   def foo
+       5:     _x = 1 + 1
+       6:   end
+       7: end
+       8: ThreadTraceInnerClass.new.foo
+       9: th.set_trace_func(nil)
+      EOF
+    end
+    th.join
+
+    [["c-return", 1, :set_trace_func, Thread, :set],
+     ["line", 2, __method__, self.class, :set],
+     ["c-call", 2, :add_trace_func, Thread, :set]].each do |e|
+      assert_equal(e, events[:set].shift)
+    end
+
+    [["c-return", 2, :add_trace_func, Thread],
+     ["line", 3, __method__, self.class],
+     ["c-call", 3, :inherited, Class],
+     ["c-return", 3, :inherited, Class],
+     ["class", 3, nil, nil],
+     ["line", 4, nil, nil],
+     ["c-call", 4, :method_added, Module],
+     ["c-return", 4, :method_added, Module],
+     ["end", 7, nil, nil],
+     ["line", 8, __method__, self.class],
+     ["c-call", 8, :new, Class],
+     ["c-call", 8, :initialize, BasicObject],
+     ["c-return", 8, :initialize, BasicObject],
+     ["c-return", 8, :new, Class],
+     ["call", 4, :foo, ThreadTraceInnerClass],
+     ["line", 5, :foo, ThreadTraceInnerClass],
+     ["c-call", 5, :+, Fixnum],
+     ["c-return", 5, :+, Fixnum],
+     ["return", 6, :foo, ThreadTraceInnerClass],
+     ["line", 9, __method__, self.class],
+     ["c-call", 9, :set_trace_func, Thread]].each do |e|
+      [:set, :add].each do |type|
+        assert_equal(e + [type], events[type].shift)
+      end
+    end
+    assert_equal([], events[:set])
+    assert_equal([], events[:add])
+  end
+
+  def test_trace_defined_method
+    events = []
+    name = "#{self.class}\##{__method__}"
+    eval <<-EOF.gsub(/^.*?: /, ""), nil, name
+     1: class FooBar; define_method(:foobar){}; end
+     2: fb = FooBar.new
+     3: set_trace_func(Proc.new { |event, file, lineno, mid, binding, klass|
+     4:   events << [event, lineno, mid, klass] if file == name
+     5: })
+     6: fb.foobar
+     7: set_trace_func(nil)
+    EOF
+
+    #[["c-return", 3, :set_trace_func, Kernel],
+    [["c-return", 5, :set_trace_func, Kernel],
+     ["line", 6, __method__, self.class],
+     ["call", 6, :foobar, FooBar],
+     ["return", 6, :foobar, FooBar],
+     ["line", 7, __method__, self.class],
+     ["c-call", 7, :set_trace_func, Kernel]].each{|e|
+      assert_equal(e, events.shift)
+    }
+  end
+
+  def test_remove_in_trace
+    bug3921 = '[ruby-dev:42350]'
+    ok = false
+    func = lambda{|e, f, l, i, b, k|
+      set_trace_func(nil)
+      ok = eval("self", b)
+    }
+
+    set_trace_func(func)
+    assert_equal(self, ok, bug3921)
+  end
+
+  def assert_security_error_safe4(block)
+    assert_raise(SecurityError) do
+      block.call
+    end
+  end
+
+  def test_set_safe4
+    func = proc do
+      $SAFE = 4
+      set_trace_func(lambda {|*|})
+    end
+    assert_security_error_safe4(func)
+  end
+
+  def test_thread_set_safe4
+    th = Thread.start {sleep}
+    func = proc do
+      $SAFE = 4
+      th.set_trace_func(lambda {|*|})
+    end
+    assert_security_error_safe4(func)
+  ensure
+    th.kill
+  end
+
+  def test_thread_add_safe4
+    th = Thread.start {sleep}
+    func = proc do
+      $SAFE = 4
+      th.add_trace_func(lambda {|*|})
+    end
+    assert_security_error_safe4(func)
+  ensure
+    th.kill
+  end
+
+  class << self
+    define_method(:method_added, Module.method(:method_added))
+  end
+
+  def trace_by_tracepoint *trace_events
+    events = []
+    trace = nil
+    xyzzy = nil
+    _local_var = :outer
+    raised_exc = nil
+    method = :trace_by_tracepoint
+    _get_data = lambda{|tp|
+      case tp.event
+      when :return, :c_return
+        tp.return_value
+      when :raise
+        tp.raised_exception
+      else
+        :nothing
+      end
+    }
+    _defined_class = lambda{|tp|
+      klass = tp.defined_class
+      begin
+        # If it is singleton method, then return original class
+        # to make compatible with set_trace_func().
+        # This is very ad-hoc hack. I hope I can make more clean test on it.
+        case klass.inspect
+        when /Class:TracePoint/; return TracePoint
+        when /Class:Exception/; return Exception
+        else klass
+        end
+      rescue Exception => e
+        e
+      end if klass
+    }
+
+    trace = nil
+    begin
+    eval <<-EOF.gsub(/^.*?: /, ""), nil, 'xyzzy'
+    1: trace = TracePoint.trace(*trace_events){|tp|
+    2:   events << [tp.event, tp.lineno, tp.path, _defined_class.(tp), tp.method_id, tp.self, tp.binding.eval("_local_var"), _get_data.(tp)] if tp.path == 'xyzzy'
+    3: }
+    4: 1.times{|;_local_var| _local_var = :inner
+    5:   tap{}
+    6: }
+    7: class XYZZY
+    8:   _local_var = :XYZZY_outer
+    9:   def foo
+   10:     _local_var = :XYZZY_foo
+   11:     bar
+   12:   end
+   13:   def bar
+   14:     _local_var = :XYZZY_bar
+   15:     tap{}
+   16:   end
+   17: end
+   18: xyzzy = XYZZY.new
+   19: xyzzy.foo
+   20: begin; raise RuntimeError; rescue RuntimeError => raised_exc; end
+   21: trace.disable
+    EOF
+    self.class.class_eval{remove_const(:XYZZY)}
+    ensure
+      trace.disable if trace && trace.enabled?
+    end
+
+    answer_events = [
+     #
+     [:c_return, 1, "xyzzy", TracePoint,  :trace,           TracePoint,  :outer,  trace],
+     [:line,     4, 'xyzzy', self.class,  method,           self,        :outer, :nothing],
+     [:c_call,   4, 'xyzzy', Integer,     :times,           1,           :outer, :nothing],
+     [:line,     4, 'xyzzy', self.class,  method,           self,        nil,    :nothing],
+     [:line,     5, 'xyzzy', self.class,  method,           self,        :inner, :nothing],
+     [:c_call,   5, 'xyzzy', Kernel,      :tap,             self,        :inner, :nothing],
+     [:c_return, 5, "xyzzy", Kernel,      :tap,             self,        :inner, self],
+     [:c_return, 4, "xyzzy", Integer,     :times,           1,           :outer, 1],
+     [:line,     7, 'xyzzy', self.class,  method,           self,        :outer, :nothing],
+     [:c_call,   7, "xyzzy", Class,       :inherited,       Object,      :outer, :nothing],
+     [:c_return, 7, "xyzzy", Class,       :inherited,       Object,      :outer, nil],
+     [:class,    7, "xyzzy", nil,         nil,              xyzzy.class, nil,    :nothing],
+     [:line,     8, "xyzzy", nil,         nil,              xyzzy.class, nil,    :nothing],
+     [:line,     9, "xyzzy", nil,         nil,              xyzzy.class, :XYZZY_outer, :nothing],
+     [:c_call,   9, "xyzzy", Module,      :method_added,    xyzzy.class, :XYZZY_outer, :nothing],
+     [:c_return, 9, "xyzzy", Module,      :method_added,    xyzzy.class, :XYZZY_outer, nil],
+     [:line,    13, "xyzzy", nil,         nil,              xyzzy.class, :XYZZY_outer, :nothing],
+     [:c_call,  13, "xyzzy", Module,      :method_added,    xyzzy.class, :XYZZY_outer, :nothing],
+     [:c_return,13, "xyzzy", Module,      :method_added,    xyzzy.class, :XYZZY_outer, nil],
+     [:end,     17, "xyzzy", nil,         nil,              xyzzy.class, :XYZZY_outer, :nothing],
+     [:line,    18, "xyzzy", TestSetTraceFunc, method,      self,        :outer, :nothing],
+     [:c_call,  18, "xyzzy", Class,       :new,             xyzzy.class, :outer, :nothing],
+     [:c_call,  18, "xyzzy", BasicObject, :initialize,      xyzzy,       :outer, :nothing],
+     [:c_return,18, "xyzzy", BasicObject, :initialize,      xyzzy,       :outer, nil],
+     [:c_return,18, "xyzzy", Class,       :new,             xyzzy.class, :outer, xyzzy],
+     [:line,    19, "xyzzy", TestSetTraceFunc, method,      self, :outer, :nothing],
+     [:call,     9, "xyzzy", xyzzy.class, :foo,             xyzzy,       nil,  :nothing],
+     [:line,    10, "xyzzy", xyzzy.class, :foo,             xyzzy,       nil,  :nothing],
+     [:line,    11, "xyzzy", xyzzy.class, :foo,             xyzzy,       :XYZZY_foo, :nothing],
+     [:call,    13, "xyzzy", xyzzy.class, :bar,             xyzzy,       nil, :nothing],
+     [:line,    14, "xyzzy", xyzzy.class, :bar,             xyzzy,       nil, :nothing],
+     [:line,    15, "xyzzy", xyzzy.class, :bar,             xyzzy,       :XYZZY_bar, :nothing],
+     [:c_call,  15, "xyzzy", Kernel,      :tap,             xyzzy,       :XYZZY_bar, :nothing],
+     [:c_return,15, "xyzzy", Kernel,      :tap,             xyzzy,       :XYZZY_bar, xyzzy],
+     [:return,  16, "xyzzy", xyzzy.class, :bar,             xyzzy,       :XYZZY_bar, xyzzy],
+     [:return,  12, "xyzzy", xyzzy.class, :foo,             xyzzy,       :XYZZY_foo, xyzzy],
+     [:line,    20, "xyzzy", TestSetTraceFunc, method,      self,        :outer, :nothing],
+     [:line,    20, "xyzzy", TestSetTraceFunc, method,      self,        :outer, :nothing],
+     [:c_call,  20, "xyzzy", Kernel,      :raise,           self,        :outer, :nothing],
+     [:c_call,  20, "xyzzy", Exception,   :exception,       RuntimeError, :outer, :nothing],
+     [:c_call,  20, "xyzzy", Exception,   :initialize,      raised_exc,  :outer, :nothing],
+     [:c_return,20, "xyzzy", Exception,   :initialize,      raised_exc,  :outer, raised_exc],
+     [:c_return,20, "xyzzy", Exception,   :exception,       RuntimeError, :outer, raised_exc],
+     [:c_call,  20, "xyzzy", Exception,   :backtrace,       raised_exc,  :outer, :nothing],
+     [:c_return,20, "xyzzy", Exception,   :backtrace,       raised_exc,  :outer, nil],
+     [:raise,   20, "xyzzy", TestSetTraceFunc, :trace_by_tracepoint, self, :outer, raised_exc],
+     [:c_return,20, "xyzzy", Kernel,      :raise,           self,        :outer, nil],
+     [:c_call,  20, "xyzzy", Module,      :===,             RuntimeError,:outer, :nothing],
+     [:c_return,20, "xyzzy", Module,      :===,             RuntimeError,:outer, true],
+     [:line,    21, "xyzzy", TestSetTraceFunc, method,      self,        :outer, :nothing],
+     [:c_call,  21, "xyzzy", TracePoint,  :disable,         trace,       :outer, :nothing],
+     ]
+
+    return events, answer_events
+  end
+
+  def trace_by_set_trace_func
+    events = []
+    trace = nil
+    trace = trace
+    xyzzy = nil
+    xyzzy = xyzzy
+    _local_var = :outer
+    eval <<-EOF.gsub(/^.*?: /, ""), nil, 'xyzzy'
+    1: set_trace_func(lambda{|event, file, line, id, binding, klass|
+    2:   events << [event, line, file, klass, id, binding.eval('self'), binding.eval("_local_var")] if file == 'xyzzy'
+    3: })
+    4: 1.times{|;_local_var| _local_var = :inner
+    5:   tap{}
+    6: }
+    7: class XYZZY
+    8:   _local_var = :XYZZY_outer
+    9:   def foo
+   10:     _local_var = :XYZZY_foo
+   11:     bar
+   12:   end
+   13:   def bar
+   14:     _local_var = :XYZZY_bar
+   15:     tap{}
+   16:   end
+   17: end
+   18: xyzzy = XYZZY.new
+   19: xyzzy.foo
+   20: begin; raise RuntimeError; rescue RuntimeError => raised_exc; end
+   21: set_trace_func(nil)
+    EOF
+    self.class.class_eval{remove_const(:XYZZY)}
+    return events
+  end
+
+  def test_tracepoint
+    events1, answer_events = *trace_by_tracepoint(:line, :class, :end, :call, :return, :c_call, :c_return, :raise)
+
+    mesg = events1.map{|e|
+      if false
+        p [:event, e[0]]
+        p [:line_file, e[1], e[2]]
+        p [:id, e[4]]
+      end
+      "#{e[0]} - #{e[2]}:#{e[1]} id: #{e[4]}"
+    }.join("\n")
+    answer_events.zip(events1){|answer, event|
+      assert_equal answer, event, mesg
+    }
+
+    events2 = trace_by_set_trace_func
+    events1.zip(events2){|ev1, ev2|
+      ev2[0] = ev2[0].sub('-', '_').to_sym
+      assert_equal ev1[0..2], ev2[0..2], ev1.inspect
+
+      # event, line, file, klass, id, binding.eval('self'), binding.eval("_local_var")
+      assert_equal ev1[3].nil?, ev2[3].nil? # klass
+      assert_equal ev1[4].nil?, ev2[4].nil? # id
+      assert_equal ev1[6], ev2[6]           # _local_var
+    }
+
+    [:line, :class, :end, :call, :return, :c_call, :c_return, :raise].each{|event|
+      events1, answer_events = *trace_by_tracepoint(event)
+      answer_events.find_all{|e| e[0] == event}.zip(events1){|answer_line, event_line|
+        assert_equal answer_line, event_line
+      }
+    }
+  end
+
+  def test_tracepoint_object_id
+    tps = []
+    trace = TracePoint.trace(){|tp|
+      tps << tp
+    }
+    tap{}
+    tap{}
+    tap{}
+    trace.disable
+
+    # passed tp is unique, `trace' object which is genereted by TracePoint.trace
+    tps.each{|tp|
+      assert_equal trace, tp
+    }
+  end
+
+  def test_tracepoint_access_from_outside
+    tp_store = nil
+    trace = TracePoint.trace(){|tp|
+      tp_store = tp
+    }
+    tap{}
+    trace.disable
+
+    assert_raise(RuntimeError){tp_store.lineno}
+    assert_raise(RuntimeError){tp_store.event}
+    assert_raise(RuntimeError){tp_store.path}
+    assert_raise(RuntimeError){tp_store.method_id}
+    assert_raise(RuntimeError){tp_store.defined_class}
+    assert_raise(RuntimeError){tp_store.binding}
+    assert_raise(RuntimeError){tp_store.self}
+    assert_raise(RuntimeError){tp_store.return_value}
+    assert_raise(RuntimeError){tp_store.raised_exception}
+  end
+
+  def foo
+  end
+
+  def test_tracepoint_enable
+    ary = []
+    trace = TracePoint.new(:call){|tp|
+      ary << tp.method_id
+    }
+    foo
+    trace.enable{
+      foo
+    }
+    foo
+    assert_equal([:foo], ary)
+
+    trace = TracePoint.new{}
+    begin
+      assert_equal(false, trace.enable)
+      assert_equal(true, trace.enable)
+      trace.enable{}
+      assert_equal(true, trace.enable)
+    ensure
+      trace.disable
+    end
+  end
+
+  def test_tracepoint_disable
+    ary = []
+    trace = TracePoint.trace(:call){|tp|
+      ary << tp.method_id
+    }
+    foo
+    trace.disable{
+      foo
+    }
+    foo
+    trace.disable
+    assert_equal([:foo, :foo], ary)
+
+    trace = TracePoint.new{}
+    trace.enable{
+      assert_equal(true, trace.disable)
+      assert_equal(false, trace.disable)
+      trace.disable{}
+      assert_equal(false, trace.disable)
+    }
+  end
+
+  def test_tracepoint_enabled
+    trace = TracePoint.trace(:call){|tp|
+      #
+    }
+    assert_equal(true, trace.enabled?)
+    trace.disable{
+      assert_equal(false, trace.enabled?)
+      trace.enable{
+        assert_equal(true, trace.enabled?)
+      }
+    }
+    trace.disable
+    assert_equal(false, trace.enabled?)
+  end
+
+  def method_test_tracepoint_return_value obj
+    obj
+  end
+
+  def test_tracepoint_return_value
+    trace = TracePoint.new(:call, :return){|tp|
+      next if tp.path != __FILE__
+      case tp.event
+      when :call
+        assert_raise(RuntimeError) {tp.return_value}
+      when :return
+        assert_equal("xyzzy", tp.return_value)
+      end
+    }
+    trace.enable{
+      method_test_tracepoint_return_value "xyzzy"
+    }
+  end
+
+  class XYZZYException < Exception; end
+  def method_test_tracepoint_raised_exception err
+    raise err
+  end
+
+  def test_tracepoint_raised_exception
+    trace = TracePoint.new(:call, :return){|tp|
+      case tp.event
+      when :call, :return
+        assert_raise(RuntimeError) { tp.raised_exception }
+      when :raise
+        assert_equal(XYZZYError, tp.raised_exception)
+      end
+    }
+    trace.enable{
+      begin
+        method_test_tracepoint_raised_exception XYZZYException
+      rescue XYZZYException
+        # ok
+      else
+        raise
+      end
+    }
+  end
+
+  def method_for_test_tracepoint_block
+    yield
+  end
+
+  def test_tracepoint_block
+    events = []
+    TracePoint.new(:call, :return, :c_call, :b_call, :c_return, :b_return){|tp|
+      events << [
+        tp.event, tp.method_id, tp.defined_class, tp.self.class,
+        /return/ =~ tp.event ? tp.return_value : nil
+      ]
+    }.enable{
+      1.times{
+        3
+      }
+      method_for_test_tracepoint_block{
+        4
+      }
+    }
+    # pp events
+    # expected_events =
+    [[:b_call, :test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, nil],
+     [:c_call, :times, Integer, Fixnum, nil],
+     [:b_call, :test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, nil],
+     [:b_return, :test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, 3],
+     [:c_return, :times, Integer, Fixnum, 1],
+     [:call, :method_for_test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, nil],
+     [:b_call, :test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, nil],
+     [:b_return, :test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, 4],
+     [:return, :method_for_test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, 4],
+     [:b_return, :test_tracepoint_block, TestSetTraceFunc, TestSetTraceFunc, 4]
+    ].zip(events){|expected, actual|
+      assert_equal(expected, actual)
+    }
+  end
+
+  def test_tracepoint_thread
+    events = []
+    thread_self = nil
+    created_thread = nil
+    TracePoint.new(:thread_begin, :thread_end){|tp|
+      events << [Thread.current,
+                 tp.event,
+                 tp.lineno,  #=> 0
+                 tp.path,    #=> nil
+                 tp.binding, #=> nil
+                 tp.defined_class, #=> nil,
+                 tp.self.class # tp.self return creating/ending thread
+                 ]
+    }.enable{
+      created_thread = Thread.new{thread_self = self}
+      created_thread.join
+    }
+    assert_equal(self, thread_self)
+    assert_equal([created_thread, :thread_begin, 0, nil, nil, nil, Thread], events[0])
+    assert_equal([created_thread, :thread_end, 0, nil, nil, nil, Thread], events[1])
+    assert_equal(2, events.size)
+  end
+
+  def test_tracepoint_inspect
+    events = []
+    trace = TracePoint.new{|tp| events << [tp.event, tp.inspect]}
+    assert_equal("#<TracePoint:disabled>", trace.inspect)
+    trace.enable{
+      assert_equal("#<TracePoint:enabled>", trace.inspect)
+      Thread.new{}.join
+    }
+    assert_equal("#<TracePoint:disabled>", trace.inspect)
+    events.each{|(ev, str)|
+      case ev
+      when :line
+        assert_match(/ in /, str)
+      when :call, :c_call
+        assert_match(/call \`/, str) # #<TracePoint:c_call `inherited'@../trunk/test.rb:11>
+      when :return, :c_return
+        assert_match(/return \`/, str) # #<TracePoint:return `m'@../trunk/test.rb:3>
+      when /thread/
+        assert_match(/\#<Thread:/, str) # #<TracePoint:thread_end of #<Thread:0x87076c0>>
+      else
+        assert_match(/\#<TracePoint:/, str)
+      end
+    }
+  end
+
+  def test_tracepoint_exception_at_line
+    assert_raise(RuntimeError) do
+      TracePoint.new(:line) {raise}.enable {
+        1
+      }
+    end
+  end
+
+  def test_tracepoint_exception_at_return
+    assert_nothing_raised(Timeout::Error, 'infinite trace') do
+      assert_normal_exit('def m; end; TracePoint.new(:return) {raise}.enable {m}', '', timeout: 3)
+    end
+  end
+
+  def test_tracepoint_with_multithreads
+    assert_nothing_raised do
+      TracePoint.new{
+        10.times{
+          Thread.pass
+        }
+      }.enable do
+        (1..10).map{
+          Thread.new{
+            1000.times{
+            }
+          }
+        }.each{|th|
+          th.join
+        }
+      end
+    end
+  end
+
+  class FOO_ERROR < RuntimeError; end
+  class BAR_ERROR < RuntimeError; end
+  def m1_test_trace_point_at_return_when_exception
+    m2_test_trace_point_at_return_when_exception
+  end
+  def m2_test_trace_point_at_return_when_exception
+    raise BAR_ERROR
+  end
+
+  def test_trace_point_at_return_when_exception
+    bug_7624 = '[ruby-core:51128] [ruby-trunk - Bug #7624]'
+    TracePoint.new{|tp|
+      if tp.event == :return &&
+        tp.method_id == :m2_test_trace_point_at_return_when_exception
+        raise FOO_ERROR
+      end
+    }.enable do
+      assert_raise(FOO_ERROR, bug_7624) do
+        m1_test_trace_point_at_return_when_exception
+      end
+    end
+
+    bug_7668 = '[Bug #7668]'
+    ary = []
+    trace = TracePoint.new{|tp|
+      ary << tp.event
+      raise
+    }
+    begin
+      trace.enable{
+        1.times{
+          raise
+        }
+      }
+    rescue
+      assert_equal([:b_call, :b_return], ary, bug_7668)
+    end
+  end
+
+  def test_trace_point_enable_safe4
+    tp = TracePoint.new {}
+    func = proc do
+      $SAFE = 4
+      tp.enable
+    end
+    assert_security_error_safe4(func)
+  end
+
+  def test_trace_point_disable_safe4
+    tp = TracePoint.new {}
+    func = proc do
+      $SAFE = 4
+      tp.disable
+    end
+    assert_security_error_safe4(func)
+  end
+
+  def m1_for_test_trace_point_binding_in_ifunc(arg)
+    arg + nil
+  rescue
+  end
+
+  def m2_for_test_trace_point_binding_in_ifunc(arg)
+    arg.inject(:+)
+  rescue
+  end
+
+  def test_trace_point_binding_in_ifunc
+    bug7774 = '[ruby-dev:46908]'
+    src = %q{
+      tp = TracePoint.new(:raise) do |tp|
+        tp.binding
+      end
+      tp.enable do
+        obj = Object.new
+        class << obj
+          include Enumerable
+          def each
+            yield 1
+          end
+        end
+        %s
+      end
+    }
+    assert_normal_exit src % %q{obj.zip({}) {}}, bug7774
+    assert_normal_exit src % %q{
+      require 'continuation'
+      begin
+        c = nil
+        obj.sort_by {|x| callcc {|c2| c ||= c2 }; x }
+        c.call
+      rescue RuntimeError
+      end
+    }, bug7774
+
+    # TracePoint
+    tp_b = nil
+    TracePoint.new(:raise) do |tp|
+      tp_b = tp.binding
+    end.enable do
+      m1_for_test_trace_point_binding_in_ifunc(0)
+      assert_equal(self, eval('self', tp_b), '[ruby-dev:46960]')
+
+      m2_for_test_trace_point_binding_in_ifunc([0, nil])
+      assert_equal(self, eval('self', tp_b), '[ruby-dev:46960]')
+    end
+
+    # set_trace_func
+    stf_b = nil
+    set_trace_func ->(event, file, line, id, binding, klass) do
+      stf_b = binding if event == 'raise'
+    end
+    begin
+      m1_for_test_trace_point_binding_in_ifunc(0)
+      assert_equal(self, eval('self', stf_b), '[ruby-dev:46960]')
+
+      m2_for_test_trace_point_binding_in_ifunc([0, nil])
+      assert_equal(self, eval('self', stf_b), '[ruby-dev:46960]')
+    ensure
+      set_trace_func(nil)
+    end
+  end
+end


### PR DESCRIPTION
Hi, last night I finally reworked my the original TracePoint library to be compatible with Ruby 2.0's new rendition (as I mention in issue #65).

It's not quite finished. Unfortunately I don't have the time to put the final polish on, but it is very close, and it is functional. I left a few TODOs in the code about what's left to work out. There isn't much, the primary thing is the proper definitions of `raised_exception` and `return_value`. Those are new, and I am not sure how they are (or if they even can be) defined. HTH.
