### PR TITLE
(g)sub with Hash replacement

### DIFF
--- a/lib/backports/1.9.2/string.rb
+++ b/lib/backports/1.9.2/string.rb
@@ -1,0 +1,3 @@
+require 'backports/tools'
+
+Backports.require_relative_dir

--- a/lib/backports/1.9.2/string/gsub.rb
+++ b/lib/backports/1.9.2/string/gsub.rb
@@ -1,0 +1,43 @@
+class String
+  begin
+    "i".gsub(/i/, {'i' => 'j'})
+  rescue TypeError
+    alias_method :old_gsub, :gsub
+
+    def gsub(*args)
+      if block_given?
+        old_gsub(*args) { |*x| yield *x }
+      elsif args.length != 2
+        old_gsub(*args)
+      else
+        (one, two) = args
+        if two.is_a? Hash
+          old_gsub(one) do |x|
+            two[x]
+          end
+        else
+          old_gsub(*args)
+        end
+      end
+    end
+
+    alias_method :old_gsub!, :gsub!
+
+    def gsub!(*args)
+      if block_given?
+        old_gsub(*args) { |*x| yield *x }
+      elsif args.length != 2
+        old_gsub(*args)
+      else
+        (one, two) = args
+        if two.is_a? Hash
+          old_gsub(one) do |x|
+            two[x]
+          end
+        else
+          old_gsub(*args)
+        end
+      end
+    end
+  end
+end

--- a/lib/backports/1.9.2/string/sub.rb
+++ b/lib/backports/1.9.2/string/sub.rb
@@ -1,0 +1,43 @@
+class String
+  begin
+    "i".sub(/i/, {'i' => 'j'})
+  rescue TypeError
+    alias_method :old_sub, :sub
+
+    def sub(*args)
+      if block_given?
+        old_sub(*args) { |*x| yield *x }
+      elsif args.length != 2
+        old_sub(*args)
+      else
+        (one, two) = args
+        if two.is_a? Hash
+          old_sub(one) do |x|
+            two[x]
+          end
+        else
+          old_sub(*args)
+        end
+      end
+    end
+
+    alias_method :old_sub!, :sub!
+
+    def sub!(*args)
+      if block_given?
+        old_sub(*args) { |*x| yield *x }
+      elsif args.length != 2
+        old_sub(*args)
+      else
+        (one, two) = args
+        if two.is_a? Hash
+          old_sub(one) do |x|
+            two[x]
+          end
+        else
+          old_sub(*args)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since 1.9.2 Ruby supports a Hash as second argument to gsub and sub to give replacements based on the individual match.
I guess there is a better way than may implementation, but at least the gsub-part works pretty well.

Documentation is http://www.ruby-doc.org/core-1.9.2/String.html#method-i-sub and http://www.ruby-doc.org/core-1.9.2/String.html#method-i-gsub
