### PR TITLE
Make sure String#byteslice doesn't explode

### DIFF
--- a/lib/backports/1.9.3/string/byteslice.rb
+++ b/lib/backports/1.9.3/string/byteslice.rb
@@ -30,7 +30,12 @@ unless String.method_defined? :byteslice
       # Actual implementation:
       str = unpack("@#{start}a#{len}").first
       str = dup.replace(str) unless self.instance_of?(String) # Must return subclass
-      str.force_encoding(encoding)
+
+      if str.respond_to?(:encoding)
+        return str.force_encoding(encoding)
+      else
+        return str
+      end
     end
   end
 end


### PR DESCRIPTION
When running under Ruby 1.8 `String#byteslice` will throw an exception due to the `encoding` method not existing. This patch resolves that, although doesn't have any tests because I couldn't see where to implement them - I'm quite happy to add some if you can point me in the right direction.
