### PR TITLE
Indicate MIT license in .gemspec

### DIFF
--- a/backports.gemspec
+++ b/backports.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Essential backports that enable many of the nice features of Ruby 1.8.7 up to 2.1.0 for earlier versions.}
   gem.summary       = %q{Backports of Ruby features for older Ruby.}
   gem.homepage      = "http://github.com/marcandre/backports"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
This is just a simple tweak to include the license when building the Gem. I took a look at the LICENSE.txt file and it appeared to be the MIT license, so that is what I put into the .gemspec.
