### PR TITLE
Don't require backports for older versions.

### DIFF
--- a/lib/backports/1.8.7.rb
+++ b/lib/backports/1.8.7.rb
@@ -1,4 +1,6 @@
 # require this file to load all the backports of Ruby 1.8.7
-require "backports/tools"
-require "backports/std_lib"
-Backports.require_relative_dir
+if RUBY_VERSION < "1.8.7"
+  require "backports/tools"
+  require "backports/std_lib"
+  Backports.require_relative_dir
+end

--- a/lib/backports/1.8.8.rb
+++ b/lib/backports/1.8.8.rb
@@ -1,3 +1,5 @@
 # Ruby 1.8.8 has been officially cancelled. As of version 2.2 of backports, <tt>require "backports/1.8.8"</tt>
 # does nothing more than require 1.8.7 backports
-require 'backports/1.8.7'
+if RUBY_VERSION < "1.8.8"
+  require 'backports/1.8.7'
+end

--- a/lib/backports/1.8.rb
+++ b/lib/backports/1.8.rb
@@ -1,2 +1,4 @@
 # require this file to load all the backports of the Ruby 1.8.x line
-require 'backports/1.8.7'
+if RUBY_VERSION < "1.8"
+  require 'backports/1.8.7'
+end

--- a/lib/backports/1.9.1.rb
+++ b/lib/backports/1.9.1.rb
@@ -1,3 +1,5 @@
 # require this file to load all the backports up to Ruby 1.9.1 (including all of 1.8.8 and below)
-require 'backports/1.8'
-Backports.require_relative_dir
+if RUBY_VERSION < "1.9.1"
+  require 'backports/1.8'
+  Backports.require_relative_dir
+end

--- a/lib/backports/1.9.2.rb
+++ b/lib/backports/1.9.2.rb
@@ -1,3 +1,5 @@
 # require this file to load all the backports up to Ruby 1.9.2
-require 'backports/1.9.1'
-Backports.require_relative_dir
+if RUBY_VERSION < "1.9.2"
+  require 'backports/1.9.1'
+  Backports.require_relative_dir
+end

--- a/lib/backports/1.9.3.rb
+++ b/lib/backports/1.9.3.rb
@@ -1,3 +1,5 @@
 # require this file to load all the backports up to Ruby 1.9.3
-require 'backports/1.9.2'
-Backports.require_relative_dir
+if RUBY_VERSION < "1.9.3"
+  require 'backports/1.9.2'
+  Backports.require_relative_dir
+end

--- a/lib/backports/1.9.rb
+++ b/lib/backports/1.9.rb
@@ -1,2 +1,4 @@
 # require this file to load all the backports of Ruby 1.9.x
-require 'backports/1.9.3'
+if RUBY_VERSION < "1.9"
+  require 'backports/1.9.3'
+end

--- a/lib/backports/2.0.0.rb
+++ b/lib/backports/2.0.0.rb
@@ -1,3 +1,5 @@
 # require this file to load all the backports up to Ruby 2.0.0
-require 'backports/1.9'
-Backports.require_relative_dir
+if RUBY_VERSION < "2.0.0"
+  require 'backports/1.9'
+  Backports.require_relative_dir
+end

--- a/lib/backports/2.0.rb
+++ b/lib/backports/2.0.rb
@@ -1,2 +1,4 @@
 # require this file to load all the backports of Ruby 2.0.x
-require 'backports/2.0.0'
+if RUBY_VERSION < "2.0"
+  require 'backports/2.0.0'
+end

--- a/lib/backports/2.1.0.rb
+++ b/lib/backports/2.1.0.rb
@@ -1,3 +1,5 @@
 # require this file to load all the backports up to Ruby 2.1.0
-require 'backports/2.0'
-Backports.require_relative_dir
+if RUBY_VERSION < "2.1.0"
+  require 'backports/2.0'
+  Backports.require_relative_dir
+end

--- a/lib/backports/2.1.rb
+++ b/lib/backports/2.1.rb
@@ -1,2 +1,4 @@
 # require this file to load all the backports of Ruby 2.1 and below
-require 'backports/2.1.0'
+if RUBY_VERSION < "2.1"
+  require 'backports/2.1.0'
+end


### PR DESCRIPTION
The following exception is raised when prime.rb and backports.rb are loaded.
I found this problem when I tried to load nmatrix and statsample.

Is there any reason to load backports for older versions of Ruby?

```
lexington:~$ ruby -v                           
ruby 2.4.0dev (2016-02-04 eval_using 53738) [x86_64-linux]
last_commit=add the using: option for {instance,class,module}_eval.
lexington:~$ ruby -r prime -r backports -e 0 
/home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/1.9.1/stdlib/prime.rb:86:in `<class:Prime>': private method `new' called for Prime:Class (NoMethodError)
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/1.9.1/stdlib/prime.rb:83:in `<top (required)>'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/std_lib.rb:9:in `require_with_backports'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/tools/std_lib.rb:50:in `block in extend_relative'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/tools/std_lib.rb:47:in `each'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/tools/std_lib.rb:47:in `extend_relative'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/1.9.1/stdlib.rb:1:in `<top (required)>'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/std_lib.rb:9:in `require_with_backports'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/tools/require_relative_dir.rb:10:in `block in require_relative_dir'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/tools/require_relative_dir.rb:9:in `each'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/tools/require_relative_dir.rb:9:in `require_relative_dir'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/1.9.1.rb:3:in `<top (required)>'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/1.9.2.rb:2:in `<top (required)>'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/1.9.3.rb:2:in `<top (required)>'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/1.9.rb:2:in `<top (required)>'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/2.0.0.rb:2:in `<top (required)>'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/2.0.rb:2:in `<top (required)>'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/2.1.0.rb:2:in `<top (required)>'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports/2.1.rb:2:in `<top (required)>'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/shugo/local/lib/ruby/gems/2.4.0/gems/backports-3.6.7/lib/backports.rb:3:in `<top (required)>'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:127:in `require'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:127:in `rescue in require'
	from /home/shugo/local/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:40:in `require'
```
