### PR TITLE
Add backports for dup of immediates

### DIFF
--- a/frozen_old_spec/tags/2.4.0/core/nil/dup_spec.rb
+++ b/frozen_old_spec/tags/2.4.0/core/nil/dup_spec.rb
@@ -1,0 +1,1 @@
+fails:NilClass#dup raises a TypeError

--- a/lib/backports/2.4.0/false/dup.rb
+++ b/lib/backports/2.4.0/false/dup.rb
@@ -1,0 +1,4 @@
+class FalseClass
+    def dup; false end
+end
+

--- a/lib/backports/2.4.0/fixnum/dup.rb
+++ b/lib/backports/2.4.0/fixnum/dup.rb
@@ -1,0 +1,6 @@
+class Fixnum
+    def dup
+        self
+    end
+end
+

--- a/lib/backports/2.4.0/float/dup.rb
+++ b/lib/backports/2.4.0/float/dup.rb
@@ -1,0 +1,4 @@
+class Float
+    def dup; self end
+end
+

--- a/lib/backports/2.4.0/nil/dup.rb
+++ b/lib/backports/2.4.0/nil/dup.rb
@@ -1,0 +1,4 @@
+class NilClass
+    def dup; nil end
+end
+

--- a/lib/backports/2.4.0/true/dup.rb
+++ b/lib/backports/2.4.0/true/dup.rb
@@ -1,0 +1,4 @@
+class TrueClass
+    def dup; true end
+end
+


### PR DESCRIPTION
This PR add backports for #dup on immediates since 2.4. They are now returning self instead of raising TypeError.

The PR also updates the rubyspec to master to get the corresponding specs (added [by this pull request](https://github.com/ruby/spec/pull/472)).