### PR TITLE
add missing string.rb for recursive require of 2.4 features

### DIFF
--- a/lib/backports/2.4.0/string.rb
+++ b/lib/backports/2.4.0/string.rb
@@ -1,0 +1,3 @@
+require 'backports/tools/require_relative_dir'
+
+Backports.require_relative_dir


### PR DESCRIPTION
Before:

```
2.3.5 :001 > require 'backports/2.4.0'
 => true 
2.3.5 :002 > 'a'.match?(/a/)
NoMethodError: undefined method `match?' for "a":String
Did you mean?  match
	from (irb):2
```

After:

```
2.3.5 :002 > require 'backports/2.4.0'
 => true 
2.3.5 :003 > 'a'.match?(/a/)
 => true 
````