### PR TITLE
update the all require to start with 2.4 features

### DIFF
--- a/lib/backports.rb
+++ b/lib/backports.rb
@@ -1,3 +1,3 @@
 require "backports/version"
-require "backports/2.1"
+require "backports/2.4"
 require "backports/rails"


### PR DESCRIPTION
The documentation says:

> For example, any version of Ruby up to today's standards:

`require 'backports'`

This makes that true again, since currently it misses all of the 2.2/2.3/2.4 features by default.