### PR TITLE
Avoid warnings for Dir backports

### DIFF
--- a/lib/backports/2.5.0/dir/children.rb
+++ b/lib/backports/2.5.0/dir/children.rb
@@ -1,5 +1,5 @@
 class Dir
-  Backports::EXCLUDED_CHILDREN = ['.', '..'].freeze
+  Backports::EXCLUDED_CHILDREN = ['.', '..'].freeze unless Backports.const_defined?('EXCLUDED_CHILDREN')
   def self.children(*args)
     entries(*args) - Backports::EXCLUDED_CHILDREN
   end

--- a/lib/backports/2.5.0/dir/each_child.rb
+++ b/lib/backports/2.5.0/dir/each_child.rb
@@ -1,5 +1,5 @@
 class Dir
-  Backports::EXCLUDED_CHILDREN = ['.', '..'].freeze
+  Backports::EXCLUDED_CHILDREN = ['.', '..'].freeze unless Backports.const_defined?('EXCLUDED_CHILDREN')
   def self.each_child(*args)
     return to_enum(__method__, *args) unless block_given?
     foreach(*args) { |f| yield f unless Backports::EXCLUDED_CHILDREN.include? f }

--- a/lib/backports/2.5.0/struct/new.rb
+++ b/lib/backports/2.5.0/struct/new.rb
@@ -1,4 +1,3 @@
-puts "asdasd"
 if RUBY_VERSION >= '2.0.0' && (Struct.new(:a, :keyword_init => true) && false rescue true)
   require 'backports/tools/alias_method_chain'
   eval %q[


### PR DESCRIPTION
Before:
```ruby
$ irb -rbackports/latest
/home/zverok/.rvm/gems/ruby-2.3.3/gems/backports-3.11.0/lib/backports/2.5.0/dir/each_child.rb:2: warning: already initialized constant Backports::EXCLUDED_CHILDREN
/home/zverok/.rvm/gems/ruby-2.3.3/gems/backports-3.11.0/lib/backports/2.5.0/dir/children.rb:2: warning: previous definition of EXCLUDED_CHILDREN was here
asdasd
2.3.3 :001 > 
```
After:
```ruby
$ irb -rbackports/latest
2.3.3 :001 > 
```
(`asdasd` was a nice touch, should I say)

I am not sure whether the const duplication should be solved in a smarter way, though.