### PR TITLE
Add rubygems metadata

### DIFF
--- a/backports.gemspec
+++ b/backports.gemspec
@@ -17,4 +17,10 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+  
+  if gem.respond_to?(:metadata)
+    gem.metadata['changelog_uri'] = 'https://github.com/marcandre/backports/blob/master/CHANGELOG.rdoc'
+    gem.metadata['source_code_uri'] = 'https://github.com/marcandre/backports'
+    gem.metadata['bug_tracker_uri'] = 'https://github.com/marcandre/backports/issues'
+  end
 end


### PR DESCRIPTION
Add metadata links for quick access from the rubygems catalogue.