### PR TITLE
Fix tests in patch versions of Ruby

### DIFF
--- a/default.mspec
+++ b/default.mspec
@@ -2,7 +2,12 @@ if (Backports::TARGET_VERSION rescue false) # Conf loaded at different times, no
   class MSpecScript
     # The set of substitutions to transform a spec filename
     # into a tag filename.
-    set :tags_patterns, [ [%r(rubyspec/), "tags/#{RUBY_VERSION}/"] ]
+    main_version = RUBY_VERSION
+    unless File.exist?(File.expand_path("../lib/backports/#{main_version}.rb", __FILE__))
+      main_version = main_version.sub(/\.\d+$/, '.0')
+    end
+
+    set :tags_patterns, [ [%r(rubyspec/), "tags/#{main_version}/"] ]
   end
 
   SpecGuard.ruby_version_override = Backports::TARGET_VERSION if Backports::TARGET_VERSION > RUBY_VERSION

--- a/test/_backport_guards_test.rb
+++ b/test/_backport_guards_test.rb
@@ -94,7 +94,11 @@ class AAA_TestBackportGuards < Test::Unit::TestCase
     before = digest
     latest = "2.4.0"
     if RUBY_VERSION > '1.8.6'
-      require "backports/#{[RUBY_VERSION, latest].min}"
+      main_version = [RUBY_VERSION, latest].min
+      unless File.exist?(File.expand_path("../../lib/backports/#{main_version}.rb", __FILE__))
+        main_version = main_version.sub(/\.\d+$/, '.0')
+      end
+      require "backports/#{main_version}"
       after = digest
       assert_nil digest_delta(before, after)
     end


### PR DESCRIPTION
Solves problems when running tests on patch version of ruby, ex 2.2.7 instead of 2.2.0.