### PR TITLE
Fix return value for String#codepoints

### DIFF
--- a/lib/backports/1.9.1/string/codepoints.rb
+++ b/lib/backports/1.9.1/string/codepoints.rb
@@ -3,6 +3,7 @@ unless String.method_defined? :codepoints
     def codepoints
       return to_enum(:codepoints) unless block_given?
       unpack("U*").each{|cp| yield cp}
+      self
     end
   end
 end


### PR DESCRIPTION
In Ruby 1.9.1 `codepoints` returns an enumerator when no block is given:
```ruby
'ABC'.codepoints
#=> #<Enumerator: "ABC":codepoints>
```
The backports version does the same.

If however a block is given, the native implementation returns the receiver, making it chainable:
```ruby
'ABC'.codepoints {}
#=> "ABC"
```
whereas the backports version returns the codepoints:

```ruby
'ABC'.codepoints {}
#=> [65, 66, 67]
```

This commit fixes the return value by returning `self`.