### PR TITLE
Simplify Array#union

### DIFF
--- a/lib/backports/2.6.0/array/union.rb
+++ b/lib/backports/2.6.0/array/union.rb
@@ -1,5 +1,5 @@
 class Array
   def union(*arrays)
-    [self, *arrays].inject([], :|)
+    arrays.inject(self, :|)
   end unless method_defined? :union
 end


### PR DESCRIPTION
We can avoid the intermediate array by using `self` instead of `[]` as the initial object for `inject`