### PR TITLE
Proc/Method #<< and #>> composition methods

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -94,6 +94,12 @@ Compatible with Ruby itself, JRuby and Rubinius.
 * Kernel
   * +then+
 
+* Method
+  * +<<+, +>>+
+
+* Proc
+  * +<<+, +>>+
+
 == Ruby 2.5 backports
 
 * Array

--- a/lib/backports/2.6.0/method.rb
+++ b/lib/backports/2.6.0/method.rb
@@ -1,0 +1,3 @@
+require 'backports/tools/require_relative_dir'
+
+Backports.require_relative_dir

--- a/lib/backports/2.6.0/method/compose.rb
+++ b/lib/backports/2.6.0/method/compose.rb
@@ -1,0 +1,13 @@
+unless Method.method_defined?(:<<) || Method.method_defined?(:>>)
+  require 'backports/2.6.0/proc/compose'
+
+  class Method
+    def <<(g)
+      to_proc << g
+    end
+
+    def >>(g)
+      to_proc >> g
+    end
+  end
+end

--- a/lib/backports/2.6.0/proc.rb
+++ b/lib/backports/2.6.0/proc.rb
@@ -1,0 +1,3 @@
+require 'backports/tools/require_relative_dir'
+
+Backports.require_relative_dir

--- a/lib/backports/2.6.0/proc/compose.rb
+++ b/lib/backports/2.6.0/proc/compose.rb
@@ -1,0 +1,19 @@
+unless Proc.method_defined?(:<<) || Proc.method_defined?(:>>)
+  class Proc
+    def <<(g)
+      if lambda?
+        lambda { |*args, &blk| call(g.call(*args, &blk)) }
+      else
+        proc { |*args, &blk| call(g.call(*args, &blk)) }
+      end
+    end
+
+    def >>(g)
+      if lambda?
+        lambda { |*args, &blk| g.call(call(*args, &blk)) }
+      else
+        proc { |*args, &blk| g.call(call(*args, &blk)) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the Ruby 2.6 function composition methods #<< and #>>. The code came from https://www.ghostcassette.com/function-composition-in-ruby/