### PR TITLE
Fix version guard

### DIFF
--- a/lib/backports/version.rb
+++ b/lib/backports/version.rb
@@ -1,3 +1,3 @@
 module Backports
-  VERSION = "3.15.0" unless const_defined? :VERSION # the guard is against a redefinition warning that happens on Travis
+  VERSION = "3.15.0" unless Backports.constants.include? :VERSION # the guard is against a redefinition warning that happens on Travis
 end


### PR DESCRIPTION
Currently, the use of Mixins might trigger wrong setting of version information.
See example below.

```
module Test
    VERSION = "1.0.0"
end
include Test
require 'backports'
Backports::VERSION

NameError (uninitialized constant Backports::VERSION)
Did you mean?  VERSION
```