### PR TITLE
Add Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,144 @@
+AllCops:
+  DisplayCopNames: true
+  TargetRubyVersion: 2.3
+  Exclude:
+    - 'frozen_old_spec/**/*'
+    - 'spec/**/*'
+    - 'test/**/*'
+    - 'tools/**/*'
+    - 'Rakefile'
+    - 'Gemfile'
+    - '*.gemspec'
+    - 'default.mspec'
+    - 'set_version/setter.rb'
+    - 'lib/backports/1.*/**/*'
+    - 'lib/backports/1.*.rb'
+    - 'lib/backports/2.{0,1}.*/**/*'
+    - 'lib/backports/random/*'
+    - 'lib/backports/force/*'
+    - 'lib/backports/rails/*'
+    - 'lib/backports/rails.rb'
+    - 'lib/backports/tools/*'
+    - 'lib/backports/basic_object.rb'
+    - 'lib/backports/std_lib.rb'
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 150
+
+Layout/SpaceBeforeBlockBraces:
+  EnforcedStyleForEmptyBraces: no_space
+
+# In current checked codebase, there is ~70 occurences of blocks
+# with spaces before last brace, and ~50 of blocks without.
+Layout/SpaceInsideBlockBraces:
+  Enabled: false
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
+Lint/EmptyWhen:
+  Enabled: false
+
+Lint/UnifiedInteger:
+  Enabled: false
+
+Metrics:
+  Enabled: false
+
+Naming:
+  Enabled: false
+
+Security/Eval:
+  Exclude:
+    - 'lib/backports/2.5.0/string/undump.rb'
+
+Style/AccessModifierDeclarations:
+  Enabled: false
+
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
+Style/AndOr:
+  EnforcedStyle: conditionals
+
+Style/CaseEquality:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/EmptyElse:
+  Enabled: false
+
+Style/EvalWithLocation:
+  Exclude:
+    - 'lib/backports/2.5.0/string/undump.rb'
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/MultilineIfModifier:
+  Enabled: false
+
+Style/MultipleComparison:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/NilComparison:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/RescueModifier:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/HashTransformKeys:
+  Enabled: false
+
+Style/HashTransformValues:
+  Enabled: false
+
+
+# TODO: Can be changed after 1.8 support will be dropped
+
+# 1.8 doesn't support leading comma style (which is currently preferred in
+# community and default in Rubocop)
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Style/ExpandPathArguments:
+  Enabled: false
+
+Style/HashEachMethods:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+
+Style/Lambda:
+  EnforcedStyle: lambda
+
+Style/SymbolArray:
+  EnforcedStyle: brackets
+
+Style/SymbolProc:
+  Enabled: false
+

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,12 @@ group :test do
   gem 'test-unit', '~>2.1.1.0'
 end
 
+if RUBY_VERSION >= '2.3.0'
+  group :development do
+    gem 'rubocop', '~> 0.80.0'
+  end
+end
+
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/Rakefile
+++ b/Rakefile
@@ -90,7 +90,13 @@ task :spec_tag, :path do |t, args|
   Rake::Task[:spec].invoke(args[:path], 'tag -G fails')
 end
 
-task :default => [:test, :all_spec]
+if RUBY_VERSION >= '2.3.0'
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+  task :default => [:rubocop, :test, :all_spec]
+else
+  task :default => [:test, :all_spec]
+end
 
 DEPENDENCIES = Hash.new([]).merge!(
   '1.8.7/argf/chars'     => 'backports/1.8.7/string/each_char',

--- a/lib/backports/2.2.0/enumerable/slice_after.rb
+++ b/lib/backports/2.2.0/enumerable/slice_after.rb
@@ -7,7 +7,7 @@ unless Enumerable.method_defined? :slice_after
       raise ArgumentError, 'both pattern and block are given' if pattern != Backports::Undefined && block
       raise ArgumentError, 'wrong number of arguments (given 0, expected 1)' if pattern == Backports::Undefined && !block
       enum = self
-      block ||= Proc.new{|elem| pattern === elem}
+      block ||= proc {|elem| pattern === elem}
       Enumerator.new do |y|
         acc = []
         enum.each do |*elem|

--- a/lib/backports/2.2.0/float/next_float.rb
+++ b/lib/backports/2.2.0/float/next_float.rb
@@ -4,7 +4,7 @@ unless Float.method_defined? :next_float
   class Float
     def next_float
       return Float::INFINITY if self == Float::INFINITY
-      r = Backports.integer_to_float(Backports.float_to_integer(self)+1)
+      r = Backports.integer_to_float(Backports.float_to_integer(self) + 1)
       r == 0 ? -0.0 : r # Map +0.0 to -0.0
     end
   end

--- a/lib/backports/2.2.0/float/prev_float.rb
+++ b/lib/backports/2.2.0/float/prev_float.rb
@@ -5,7 +5,7 @@ unless Float.method_defined? :prev_float
   class Float
     def prev_float
       return -Float::INFINITY if self == -Float::INFINITY
-      Backports.integer_to_float(Backports.float_to_integer(self)-1)
+      Backports.integer_to_float(Backports.float_to_integer(self) - 1)
     end
   end
 end

--- a/lib/backports/2.2.0/method/super_method.rb
+++ b/lib/backports/2.2.0/method/super_method.rb
@@ -6,10 +6,10 @@ unless Method.method_defined? :super_method
       singleton_klass = class << receiver; self; end
       call_chain = singleton_klass.ancestors
       # find current position in call chain:
-      skip = call_chain.find_index{|c| c == owner} or return
+      skip = call_chain.find_index {|c| c == owner} or return
       call_chain = call_chain.drop(skip + 1)
       # find next in chain with a definition:
-      next_index = call_chain.find_index{|c| c.method_defined? name}
+      next_index = call_chain.find_index {|c| c.method_defined? name}
       next_index && call_chain[next_index].instance_method(name).bind(receiver)
     end
   end

--- a/lib/backports/2.3.0/array/bsearch_index.rb
+++ b/lib/backports/2.3.0/array/bsearch_index.rb
@@ -5,7 +5,7 @@ unless Array.method_defined? :bsearch_index
       from = 0
       to   = size - 1
       satisfied = nil
-      while from <= to do
+      while from <= to
         midpoint = (from + to).div(2)
         result = yield(self[midpoint])
         case result

--- a/lib/backports/2.3.0/hash/lt.rb
+++ b/lib/backports/2.3.0/hash/lt.rb
@@ -5,7 +5,7 @@ unless Hash.method_defined? :<
       hash = Backports.coerce_to_hash(hash)
       return false unless size < hash.size
       each do |k, v|
-        v2 = hash.fetch(k){ return false }
+        v2 = hash.fetch(k) { return false }
         return false unless v2 == v
       end
       true

--- a/lib/backports/2.3.0/hash/lte.rb
+++ b/lib/backports/2.3.0/hash/lte.rb
@@ -5,7 +5,7 @@ unless Hash.method_defined? :<=
       hash = Backports.coerce_to_hash(hash)
       return false unless size <= hash.size
       each do |k, v|
-        v2 = hash.fetch(k){ return false }
+        v2 = hash.fetch(k) { return false }
         return false unless v2 == v
       end
       true

--- a/lib/backports/2.3.0/hash/to_proc.rb
+++ b/lib/backports/2.3.0/hash/to_proc.rb
@@ -2,7 +2,7 @@ unless Hash.method_defined? :to_proc
   class Hash
     def to_proc
       h = self
-      Proc.new{|*args| h[*args]}
+      proc {|*args| h[*args]}
     end
   end
 end

--- a/lib/backports/2.3.0/struct/dig.rb
+++ b/lib/backports/2.3.0/struct/dig.rb
@@ -2,11 +2,10 @@ unless Struct.method_defined? :dig
   class Struct
     def dig(key, *rest)
       return nil unless respond_to?(key)
-      val = self.public_send(key)
+      val = public_send(key)
       return val if rest.empty? || val == nil
       raise TypeError, "#{val.class} does not have #dig method" unless val.respond_to? :dig
       val.dig(*rest)
     end
   end
 end
-

--- a/lib/backports/2.4.0/hash/transform_values.rb
+++ b/lib/backports/2.4.0/hash/transform_values.rb
@@ -1,6 +1,6 @@
 class Hash
   def transform_values
-    return to_enum(:transform_values){ size } unless block_given?
+    return to_enum(:transform_values) { size } unless block_given?
     h = {}
     each do |key, value|
       h[key] = yield value
@@ -9,7 +9,7 @@ class Hash
   end unless method_defined? :transform_values
 
   def transform_values!
-    return to_enum(:transform_values!){ size } unless block_given?
+    return to_enum(:transform_values!) { size } unless block_given?
     reject!{} if frozen? # Force error triggerring if frozen, in case of empty array
     each do |key, value|
       self[key] = yield value

--- a/lib/backports/2.4.0/true_class/dup.rb
+++ b/lib/backports/2.4.0/true_class/dup.rb
@@ -3,4 +3,3 @@ class TrueClass
     self
   end
 end unless (true.dup rescue false)
-

--- a/lib/backports/2.5.0/hash/transform_keys.rb
+++ b/lib/backports/2.5.0/hash/transform_keys.rb
@@ -1,6 +1,6 @@
 class Hash
   def transform_keys
-    return to_enum(:transform_keys){ size } unless block_given?
+    return to_enum(:transform_keys) { size } unless block_given?
     h = {}
     each do |key, value|
       h[yield key] = value

--- a/lib/backports/2.5.0/integer/sqrt.rb
+++ b/lib/backports/2.5.0/integer/sqrt.rb
@@ -6,9 +6,9 @@ class Integer
   def self.sqrt(n)
     n = Backports.coerce_to_int(n)
     return Math.sqrt(n).to_i if n <= 9_999_899_999_899_999_322_536_673_279
-    bits_shift = n.bit_length/2 + 1
+    bits_shift = n.bit_length / 2 + 1
     bitn_mask = root = 1 << bits_shift
-    while true
+    loop do
       root ^= bitn_mask if (root * root) > n
       bitn_mask >>= 1
       return root if bitn_mask == 0

--- a/lib/backports/2.5.0/module/alias_method.rb
+++ b/lib/backports/2.5.0/module/alias_method.rb
@@ -1,4 +1,3 @@
 class Module
   public :alias_method
 end
-

--- a/lib/backports/2.5.0/string/undump.rb
+++ b/lib/backports/2.5.0/string/undump.rb
@@ -6,14 +6,10 @@ unless String.method_defined? :undump
       raise 'string contains null byte' if string["\0"]
       raise 'non-ASCII character detected' unless string.ascii_only?
 
-      #raise '.force_encoding("...") format is not supported by backports' if string.match(/\A".*"\.force_encoding\("[^"]*"\)\z/)
-      match = string.match(/\A(".*?"?)(?:\.force_encoding\("([^"]*)"\))?\z/)
-      if match
-        string = match[1]
-        encoding = match[2]
-      else
+      match = string.match(/\A(".*?"?)(?:\.force_encoding\("([^"]*)"\))?\z/) or
         raise %(invalid dumped string; not wrapped with '"' nor '"...".force_encoding("...")' form)
-      end
+      string = match[1]
+      encoding = match[2]
 
       # Ruby 1.9.3 does weird things to encoding during gsub
       encoding ||= string.encoding.to_s

--- a/lib/backports/2.5.0/struct/new.rb
+++ b/lib/backports/2.5.0/struct/new.rb
@@ -19,5 +19,5 @@ if RUBY_VERSION >= '2.0.0' && (Struct.new(:a, :keyword_init => true) && false re
     end
     Backports.alias_method_chain(self, :new, :keyword_init)
   end
-  ]
+  ], __FILE__, __LINE__
 end

--- a/lib/backports/2.6.0/enumerable/chain.rb
+++ b/lib/backports/2.6.0/enumerable/chain.rb
@@ -11,7 +11,10 @@ unless Enumerable.method_defined? :chain
     def initialize(*enums)
       @enums = enums
       @rewindable = -1
-      self
+      # This self is necessary to pass RubySpec,
+      # See rubyspec/core/enumerator/chain/initialize_spec.rb
+      # ...it checks what call of #initialize on non-initalized object returns
+      self # rubocop:disable Lint/Void
     end
 
     def each(*args, &block)

--- a/lib/backports/2.6.0/hash/to_h.rb
+++ b/lib/backports/2.6.0/hash/to_h.rb
@@ -1,6 +1,6 @@
 require 'backports/2.0.0/hash/to_h' unless Hash.method_defined? :to_h
 
-if {:n => true}.to_h{[:ok, true]}[:n]
+if {:n => true}.to_h {[:ok, true]}[:n]
   require 'backports/tools/alias_method_chain'
   require 'backports/2.1.0/array/to_h'
 

--- a/lib/backports/2.7.0/enumerable/filter_map.rb
+++ b/lib/backports/2.7.0/enumerable/filter_map.rb
@@ -5,10 +5,10 @@ unless Enumerable.method_defined? :filter_map
     def filter_map
       return to_enum(:filter_map) unless block_given?
 
-      each_with_object([]) { |item, res|
+      each_with_object([]) do |item, res|
         processed = yield(item)
         res << processed if processed
-      }
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is an attempt to introduce Rubocop to backports codebase.

The main goal is to make future backports easier to develop.
Some decisions made in this PR (I am ready to amend any of them):
* Old files (for Rubies before 2.1) are excluded from the check; they represent all kinds of old styles, and as they will probably never change (and will probably be dropped in v.3), there is no point either in fixing them or in trying to produce Rubocop's config that suits all styles seen in the codebase;
* Metrics (complexity, module/method length) and Naming (parameter and file names) are excluded completely as not suitable for the situation;
* Checks that the codebase is consistent about, are turned on (with the settings corresponding to codebase's preferences); 
* Checks that codebase is not consistent about are turned off when they could be situational choices...
* ...or sometimes are fixed if they are mere "either this or that" and better be consistent ("whether there should be a space before block opening brace");
* Some rubocop's suggestions are fixed when the proposed change is _obviously_ better and the problem just happens in a few places of the codebase (like redundant `self.` in method calls, redundant `do` in while cycle) etc.)

I can imagine you had in mind more "relaxed" settings, just basic sanity control, so please tell me if it is the case.

PS: I had no attempt to turn it on on CI, it is up to you if the PR would be accepted. Though, currently it fails on CI < 2.3, because can't install Rubocop :(