### PR TITLE
Fix: NameError: uninitialized constant Float::INFINITY

### DIFF
--- a/lib/backports/2.0.0/range/size.rb
+++ b/lib/backports/2.0.0/range/size.rb
@@ -1,4 +1,6 @@
 unless Range.method_defined? :size
+  require 'backports/1.9.2/float/infinity'
+
   class Range
     def size
       return nil unless self.begin.is_a?(Numeric) && self.end.is_a?(Numeric)


### PR DESCRIPTION
The full error message is:
```
NameError: uninitialized constant Float::INFINITY
    /home/khiav/.rvm/gems/ruby-1.8.7-p374/gems/backports-3.16.1/lib/backports/2.0.0/range/size.rb:7:in `size'
```