### PR TITLE
Fix 2.5 Struct.new

### DIFF
--- a/lib/backports/2.5.0/struct/new.rb
+++ b/lib/backports/2.5.0/struct/new.rb
@@ -19,5 +19,5 @@ if RUBY_VERSION >= '2.0.0' && (Struct.new(:a, :keyword_init => true) && false re
     end
     Backports.alias_method_chain(self, :new, :keyword_init)
   end
-  ], __FILE__, __LINE__
+  ], nil, __FILE__, __LINE__
 end


### PR DESCRIPTION
`Kernel.eval` accepts binding as the second argument and file and line as the latter two.

Found it while trying to use with 2.4:

```sh
$ ruby -v
ruby 2.4.10p364 (2020-03-31 revision 67879) [x86_64-linux]

$ ruby -rbackports/latest -e "p :ok"

/usr/local/bundle/gems/backports-3.17.1/lib/backports/2.5.0/struct/new.rb:3:in `eval': no implicit conversion of Integer into String (TypeError)
        from /usr/local/bundle/gems/backports-3.17.1/lib/backports/2.5.0/struct/new.rb:3:in `<top (required)>'
        from /usr/local/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /usr/local/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /usr/local/bundle/gems/backports-3.17.1/lib/backports/std_lib.rb:12:in `require_with_backports'
       ...
        from /usr/local/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:34:in `require'
```