### PR TITLE
Reduce number of requires with version-based conditions

### DIFF
--- a/lib/backports/1.8.7.rb
+++ b/lib/backports/1.8.7.rb
@@ -8,4 +8,4 @@ Backports.frown_upon :require_version,
 Backports.warned[:require_std_lib] = true
 require "backports/std_lib"
 
-Backports.require_relative_dir
+Backports.require_relative_dir if RUBY_VERSION < '1.8.7'

--- a/lib/backports/1.8.7.rb
+++ b/lib/backports/1.8.7.rb
@@ -5,7 +5,8 @@ require "backports/tools/deprecation"
 Backports.frown_upon :require_version,
   'Requiring backports/<ruby version> is not recommended in production. Require just the needed backports instead.'
 
-Backports.warned[:require_std_lib] = true
-require "backports/std_lib"
-
-Backports.require_relative_dir if RUBY_VERSION < '1.8.7'
+if RUBY_VERSION < '1.8.7'
+  Backports.warned[:require_std_lib] = true
+  require "backports/std_lib"
+  Backports.require_relative_dir
+end

--- a/lib/backports/1.9.1.rb
+++ b/lib/backports/1.9.1.rb
@@ -1,3 +1,3 @@
 # require this file to load all the backports up to Ruby 1.9.1 (including all of 1.8.8 and below)
 require 'backports/1.8'
-Backports.require_relative_dir
+Backports.require_relative_dir if RUBY_VERSION < '1.9.1'

--- a/lib/backports/1.9.1.rb
+++ b/lib/backports/1.9.1.rb
@@ -1,3 +1,8 @@
 # require this file to load all the backports up to Ruby 1.9.1 (including all of 1.8.8 and below)
 require 'backports/1.8'
-Backports.require_relative_dir if RUBY_VERSION < '1.9.1'
+
+if RUBY_VERSION < '1.9.1'
+  Backports.warned[:require_std_lib] = true
+  require "backports/std_lib"
+  Backports.require_relative_dir
+end

--- a/lib/backports/1.9.2.rb
+++ b/lib/backports/1.9.2.rb
@@ -1,3 +1,3 @@
 # require this file to load all the backports up to Ruby 1.9.2
 require 'backports/1.9.1'
-Backports.require_relative_dir
+Backports.require_relative_dir if RUBY_VERSION < '1.9.2'

--- a/lib/backports/1.9.2.rb
+++ b/lib/backports/1.9.2.rb
@@ -1,3 +1,8 @@
 # require this file to load all the backports up to Ruby 1.9.2
 require 'backports/1.9.1'
-Backports.require_relative_dir if RUBY_VERSION < '1.9.2'
+
+if RUBY_VERSION < '1.9.2'
+  Backports.warned[:require_std_lib] = true
+  require "backports/std_lib"
+  Backports.require_relative_dir
+end

--- a/lib/backports/1.9.3.rb
+++ b/lib/backports/1.9.3.rb
@@ -1,3 +1,3 @@
 # require this file to load all the backports up to Ruby 1.9.3
 require 'backports/1.9.2'
-Backports.require_relative_dir
+Backports.require_relative_dir if RUBY_VERSION < '1.9.3'

--- a/lib/backports/1.9.3.rb
+++ b/lib/backports/1.9.3.rb
@@ -1,3 +1,8 @@
 # require this file to load all the backports up to Ruby 1.9.3
 require 'backports/1.9.2'
-Backports.require_relative_dir if RUBY_VERSION < '1.9.3'
+
+if RUBY_VERSION < '1.9.3'
+  Backports.warned[:require_std_lib] = true
+  require "backports/std_lib"
+  Backports.require_relative_dir
+end

--- a/lib/backports/2.0.0.rb
+++ b/lib/backports/2.0.0.rb
@@ -1,3 +1,8 @@
 # require this file to load all the backports up to Ruby 2.0.0
 require 'backports/1.9'
-Backports.require_relative_dir if RUBY_VERSION < '2.0'
+
+if RUBY_VERSION < '2.0'
+  Backports.warned[:require_std_lib] = true
+  require "backports/std_lib"
+  Backports.require_relative_dir
+end

--- a/lib/backports/2.0.0.rb
+++ b/lib/backports/2.0.0.rb
@@ -1,3 +1,3 @@
 # require this file to load all the backports up to Ruby 2.0.0
 require 'backports/1.9'
-Backports.require_relative_dir
+Backports.require_relative_dir if RUBY_VERSION < '2.0'

--- a/lib/backports/2.1.0.rb
+++ b/lib/backports/2.1.0.rb
@@ -1,3 +1,3 @@
 # require this file to load all the backports up to Ruby 2.1.0
 require 'backports/2.0'
-Backports.require_relative_dir
+Backports.require_relative_dir if RUBY_VERSION < '2.1'

--- a/lib/backports/2.2.0.rb
+++ b/lib/backports/2.2.0.rb
@@ -1,3 +1,3 @@
 # require this file to load all the backports up to Ruby 2.2
 require 'backports/2.1'
-Backports.require_relative_dir
+Backports.require_relative_dir if RUBY_VERSION < '2.2'

--- a/lib/backports/2.3.0.rb
+++ b/lib/backports/2.3.0.rb
@@ -1,3 +1,3 @@
 # require this file to load all the backports up to Ruby 2.3
 require 'backports/2.2'
-Backports.require_relative_dir
+Backports.require_relative_dir if RUBY_VERSION < '2.3'

--- a/lib/backports/2.4.0.rb
+++ b/lib/backports/2.4.0.rb
@@ -1,3 +1,3 @@
 # require this file to load all the backports up to Ruby 2.4
 require 'backports/2.3'
-Backports.require_relative_dir
+Backports.require_relative_dir if RUBY_VERSION < '2.4'

--- a/lib/backports/2.5.0.rb
+++ b/lib/backports/2.5.0.rb
@@ -1,3 +1,3 @@
 # require this file to load all the backports up to Ruby 2.5
 require 'backports/2.4'
-Backports.require_relative_dir
+Backports.require_relative_dir if RUBY_VERSION < '2.5'

--- a/lib/backports/2.6.0.rb
+++ b/lib/backports/2.6.0.rb
@@ -1,3 +1,3 @@
 # require this file to load all the backports up to Ruby 2.5
 require 'backports/2.5'
-Backports.require_relative_dir
+Backports.require_relative_dir if RUBY_VERSION < '2.6'

--- a/lib/backports/2.7.0.rb
+++ b/lib/backports/2.7.0.rb
@@ -1,3 +1,3 @@
 # require this file to load all the backports up to Ruby 2.5
 require 'backports/2.6'
-Backports.require_relative_dir
+Backports.require_relative_dir if RUBY_VERSION < '2.7'

--- a/lib/backports/tools/require_relative_dir.rb
+++ b/lib/backports/tools/require_relative_dir.rb
@@ -7,7 +7,12 @@ module Backports
         compact.
         sort.
         each do |f|
-          require short_path + f
+          path = '../../' + short_path + f
+          if Kernel.private_method_defined?(:require_relative)
+            require_relative path
+          else
+            require File.expand_path(path)
+          end
         end
   end
 end

--- a/test/_backport_guards_test.rb
+++ b/test/_backport_guards_test.rb
@@ -1,154 +1,157 @@
-require 'stringio'
-if RUBY_VERSION < '1.9'
-  require 'enumerator'
-  require 'generator' # Must require first, because of warning in Ruby 1.8.7 with `ruby -w -r generator -e ""`
-end
-require './test/test_helper'
-$bogus = []
+# This file tests that (old) standard library backports requiring doesn't break anything.
+# It isn't relevant to Rubies > 2.0, since we stopped to backport stdlib.
 
-module Kernel
-  def require_with_bogus_extension(lib)
-    $bogus << lib
-    require_without_bogus_extension(lib)
+if RUBY_VERSION < '2.0'
+  require 'stringio'
+  if RUBY_VERSION < '1.9'
+    require 'enumerator'
+    require 'generator' # Must require first, because of warning in Ruby 1.8.7 with `ruby -w -r generator -e ""`
   end
-  alias_method :require_without_bogus_extension, :require
-  alias_method :require, :require_with_bogus_extension
+  require './test/test_helper'
+  $bogus = []
 
-  if defined? BasicObject and BasicObject.superclass
-    BasicObject.send :undef_method, :require
-    BasicObject.send :undef_method, :require_with_bogus_extension
-  end
-end
-
-class AAA_TestBackportGuards < Test::Unit::TestCase
-  def setup
-    $VERBOSE = true
-    @prev, $stderr = $stderr, StringIO.new
-  end
-
-  def teardown
-    assert_equal '', $stderr.string
-    $stderr = @prev
-  end
-
-  EXCLUDE = %w[require require_with_backports require_without_backports] # Overriden in all circumstances to load the std-lib
-  EXCLUDE.map!(&:to_sym) if instance_methods.first.is_a?(Symbol)
-
-  # For some very strange reason, Hash[kvp.flatten] doesn't always work in 1.8.6??
-  def to_hash(key_value_pairs)
-    h = {}
-    key_value_pairs.each{|k,v| h[k] = v}
-    h
-  end
-
-  # This returns all user defined methods on klass.
-  # For Ruby 1.8.7 or below, it returns all methods, so we can at least check we are not adding new methods needlessly
-  def class_signature(klass)
-    list =
-      (klass.instance_methods - EXCLUDE).map{|m| [m, klass.instance_method(m)] } +
-      (klass.methods - EXCLUDE).map{|m| [".#{m}", klass.method(m) ]}
-    list.select!{|name, method| method.source_location } if UnboundMethod.method_defined? :source_location
-    to_hash(list)
-  end
-
-  CLASSES = [Array, Binding, Bignum, Dir, Comparable, Enumerable, FalseClass, Fixnum, Float, GC,
-      Hash, Integer, IO, Kernel, Math, MatchData, Method, Module, NilClass, Numeric,
-      ObjectSpace, Proc, Process, Range, Regexp, String, Struct, Symbol, TrueClass] +
-    [ENV, ARGF].map{|obj| class << obj; self; end }
-
-  case RUBY_VERSION
-    when '1.8.6'
-    when '1.8.7'
-      CLASSES << Enumerable::Enumerator
-    else
-      CLASSES << Enumerator
-  end
-
-  def digest
-    to_hash(
-      CLASSES.map { |klass| [klass, class_signature(klass)] }
-    )
-  end
-
-  def digest_delta(before, after)
-    delta = {}
-    before.each do |klass, methods|
-      compare = after[klass]
-      d = methods.map do |name, unbound|
-        name unless unbound == compare[name]
-      end + (compare.map(&:first) - methods.map(&:first))
-      d.compact!
-      delta[klass] = d unless d.empty?
+  module Kernel
+    def require_with_bogus_extension(lib)
+      $bogus << lib
+      require_without_bogus_extension(lib)
     end
-    delta unless delta.empty?
+    alias_method :require_without_bogus_extension, :require
+    alias_method :require, :require_with_bogus_extension
+
+    if defined? BasicObject and BasicObject.superclass
+      BasicObject.send :undef_method, :require
+      BasicObject.send :undef_method, :require_with_bogus_extension
+    end
   end
 
-  # Order super important!
-  def test__1_abbrev_can_be_required_before_backports
-    assert require('abbrev')
-    assert !$LOADED_FEATURES.include?('backports')
-  end
+  class AAA_TestBackportGuards < Test::Unit::TestCase
+    def setup
+      $VERBOSE = true
+      @prev, $stderr = $stderr, StringIO.new
+    end
 
-  # Order super important!
-  def test__2_backports_wont_override_unnecessarily
-    before = digest
-    latest = "2.4.0"
-    if RUBY_VERSION > '1.8.6'
-      main_version = [RUBY_VERSION, latest].min
-      unless File.exist?(File.expand_path("../../lib/backports/#{main_version}.rb", __FILE__))
-        main_version = main_version.sub(/\.\d+$/, '.0')
+    def teardown
+      assert_equal '', $stderr.string
+      $stderr = @prev
+    end
+
+    EXCLUDE = %w[require require_with_backports require_without_backports] # Overriden in all circumstances to load the std-lib
+    EXCLUDE.map!(&:to_sym) if instance_methods.first.is_a?(Symbol)
+
+    # For some very strange reason, Hash[kvp.flatten] doesn't always work in 1.8.6??
+    def to_hash(key_value_pairs)
+      h = {}
+      key_value_pairs.each{|k,v| h[k] = v}
+      h
+    end
+
+    # This returns all user defined methods on klass.
+    # For Ruby 1.8.7 or below, it returns all methods, so we can at least check we are not adding new methods needlessly
+    def class_signature(klass)
+      list =
+        (klass.instance_methods - EXCLUDE).map{|m| [m, klass.instance_method(m)] } +
+        (klass.methods - EXCLUDE).map{|m| [".#{m}", klass.method(m) ]}
+      list.select!{|name, method| method.source_location } if UnboundMethod.method_defined? :source_location
+      to_hash(list)
+    end
+
+    CLASSES = [Array, Binding, Bignum, Dir, Comparable, Enumerable, FalseClass, Fixnum, Float, GC,
+        Hash, Integer, IO, Kernel, Math, MatchData, Method, Module, NilClass, Numeric,
+        ObjectSpace, Proc, Process, Range, Regexp, String, Struct, Symbol, TrueClass] +
+      [ENV, ARGF].map{|obj| class << obj; self; end }
+
+    case RUBY_VERSION
+      when '1.8.6'
+      when '1.8.7'
+        CLASSES << Enumerable::Enumerator
+      else
+        CLASSES << Enumerator
+    end
+
+    def digest
+      to_hash(
+        CLASSES.map { |klass| [klass, class_signature(klass)] }
+      )
+    end
+
+    def digest_delta(before, after)
+      delta = {}
+      before.each do |klass, methods|
+        compare = after[klass]
+        d = methods.map do |name, unbound|
+          name unless unbound == compare[name]
+        end + (compare.map(&:first) - methods.map(&:first))
+        d.compact!
+        delta[klass] = d unless d.empty?
       end
-      require 'backports/tools/deprecation'
-      Backports.warned = Hash.new(true)
-      require "backports/#{main_version}"
-      after = digest
-      assert_nil digest_delta(before, after)
+      delta unless delta.empty?
     end
-    if RUBY_VERSION < latest
-      require "backports"
-      after = digest
-      assert !digest_delta(before, after).nil?
-    end
-  end
 
-  if RUBY_VERSION < '2.7' # e2mmap was dropped in 2.7, and matrix reimpl depends on it
-    def test_setlib_load_correctly_after_requiring_backports
-      path = File.expand_path("../../lib/backports/1.9.2/stdlib/matrix.rb", __FILE__)
-      assert_equal false,  $LOADED_FEATURES.include?(path)
-      assert_equal true,  require('matrix')
-      assert_equal true,  $bogus.include?("matrix")
+    # Order super important!
+    def test__1_abbrev_can_be_required_before_backports
+      assert require('abbrev')
+      assert !$LOADED_FEATURES.include?('backports')
+    end
+
+    # Order super important!
+    def test__2_backports_wont_override_unnecessarily
+      before = digest
+      latest = "2.4.0"
+      if RUBY_VERSION > '1.8.6'
+        main_version = [RUBY_VERSION, latest].min
+        unless File.exist?(File.expand_path("../../lib/backports/#{main_version}.rb", __FILE__))
+          main_version = main_version.sub(/\.\d+$/, '.0')
+        end
+        require 'backports/tools/deprecation'
+        Backports.warned = Hash.new(true)
+        require "backports/#{main_version}"
+        after = digest
+        assert_nil digest_delta(before, after)
+      end
+      if RUBY_VERSION < latest
+        require "backports"
+        after = digest
+        assert !digest_delta(before, after).nil?
+      end
+    end
+
+    if RUBY_VERSION < '1.9.2' # this backport wouldn't be necessary otherwise
+      def test_setlib_load_correctly_after_requiring_backports
+        path = File.expand_path("../../lib/backports/1.9.2/stdlib/matrix.rb", __FILE__)
+        assert_equal false,  $LOADED_FEATURES.include?(path)
+        assert_equal true,  require('matrix')
+        assert_equal true,  $bogus.include?("matrix")
+        assert_equal true,  $LOADED_FEATURES.include?(path)
+        assert_equal false, require('matrix')
+      end
+    end
+
+    def test_setlib_load_correctly_before_requiring_backports_test
+      assert_equal true,  $bogus.include?("abbrev")
+      path = File.expand_path("../../lib/backports/2.0.0/stdlib/abbrev.rb", __FILE__)
       assert_equal true,  $LOADED_FEATURES.include?(path)
-      assert_equal false, require('matrix')
+      assert_equal false, require('abbrev')
     end
-  end
 
-  def test_setlib_load_correctly_before_requiring_backports_test
-    assert_equal true,  $bogus.include?("abbrev")
-    path = File.expand_path("../../lib/backports/2.0.0/stdlib/abbrev.rb", __FILE__)
-    assert_equal true,  $LOADED_FEATURES.include?(path)
-    assert_equal false, require('abbrev')
-  end
-
-  if RUBY_VERSION < '2.7' # scanf was dropped in 2.7
     def test_backports_does_not_interfere_for_libraries_without_backports_test
       assert_equal true,  require('scanf')
       assert_equal false, require('scanf')
     end
-  end
 
-  def test_load_correctly_new_libraries_test
-    path = File.expand_path("../../lib/backports/2.0.0/stdlib/fake_stdlib_lib.rb", __FILE__)
-    assert_equal false, $LOADED_FEATURES.include?(path)
-    assert_equal true,  require('fake_stdlib_lib')
-    assert_equal true,  $LOADED_FEATURES.include?(path)
-    assert_equal false, require('fake_stdlib_lib')
-  end
+    def test_load_correctly_new_libraries_test
+      path = File.expand_path("../../lib/backports/2.0.0/stdlib/fake_stdlib_lib.rb", __FILE__)
+      assert_equal false, $LOADED_FEATURES.include?(path)
+      assert_equal true,  require('fake_stdlib_lib')
+      assert_equal true,  $LOADED_FEATURES.include?(path)
+      assert_equal false, require('fake_stdlib_lib')
+    end
 
-  def test_no_warnings
-    require 'ostruct'
-    require 'set'
-    require 'backports/1.8.7/array/each'
-    require 'backports/1.8.7/enumerator/next'
-    assert_equal 1, [1,2,3].each.next # [Bug #70]
+    def test_no_warnings
+      require 'ostruct'
+      require 'set'
+      require 'backports/1.8.7/array/each'
+      require 'backports/1.8.7/enumerator/next'
+      assert_equal 1, [1,2,3].each.next # [Bug #70]
+    end
   end
 end


### PR DESCRIPTION
Well... I am aware that you are kinda frowning upon `require 'backports/latest'`, but we are using it nevertheless. One bad thing that happening in this case, is (especially in Rails-infected project with tons of `require` redefinitions) it is quite slow.

Measured with [Bumbler](https://github.com/nevir/Bumbler), our slowest requires are:
```
   ....
    578.10  aws-sdk-ec2
    682.34  aws-sdk-s3
   1117.32  backports/latest <======== :scream:
   1292.85  rails
```
That's because being on 2.6, and requiring backports to have some 2.7 stuff, we in fact perform thousands of requires, which are effectively no-ops, down to some `backports/1.8.7/range/step`... I believe that reducing number of unnecessary requires is a good thing in any case.

(Not sure what CI will say about that, though...)