### PR TITLE
fix: add missing 2.3.0/string.rb

### DIFF
--- a/lib/backports/2.3.0/string.rb
+++ b/lib/backports/2.3.0/string.rb
@@ -1,0 +1,3 @@
+require 'backports/tools/require_relative_dir'
+
+Backports.require_relative_dir


### PR DESCRIPTION
Just found that String additions are not loaded in Ruby 2.2.