### PR TITLE
Backport `Ractor`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg
 assets
 rs
 Gemfile.lock
+.ruby-version

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -134,6 +134,8 @@ Style/HashEachMethods:
 
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
+  Exclude:
+    - 'lib/backports/ractor/*.rb'
 
 Style/Lambda:
   EnforcedStyle: lambda
@@ -150,8 +152,17 @@ Style/SoleNestedConditional:
 Lint/ToEnumArguments:
   Enabled: false
 
-Style/OptionalBooleanParameter:
-  Enabled: false
+Layout/CommentIndentation:
+  Enabled: false # buggy
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma
 
 Style/RedundantBegin:
+  Enabled: false # targetting older Ruby
+
+Style/OptionalBooleanParameter:
+  Enabled: false # ok for private methods
+
+Lint/DuplicateBranch:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ end
 
 if RUBY_VERSION >= '2.4.0'
   group :development do
-    gem 'rubocop', '~> 1.1.0'
+    gem 'rubocop', '~> 1.6.0'
   end
 end

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ itself, JRuby and Rubinius.
   - `except`
   - `transform_keys`, `transform_keys!` (with hash argument)
 
+#### Ractor
+  - complete, with the caveats:
+    - uses `Thread` internally, so performance will (of course) comparable to `Ractor`
+    - will not raise some errors when `Ractor` would (in particular Ractor::IsolationError)
+    - Ruby 1.x not supported
+
 #### Symbol
   - `name`
 

--- a/Rakefile
+++ b/Rakefile
@@ -164,6 +164,7 @@ IGNORE_IN_200 = %w[
 IGNORE = %w[
   3.0.0/env/except
   3.0.0/symbol/name
+  3.0.0/ractor/ractor
 ]
 
 CLASS_MAP = Hash.new{|k, v| k[v] = v}.merge!(

--- a/lib/backports/3.0.0/ractor.rb
+++ b/lib/backports/3.0.0/ractor.rb
@@ -1,0 +1,5 @@
+if RUBY_VERSION < '2'
+  warn 'Ractor not backported to Ruby 1.x'
+else
+  require_relative '../ractor/ractor' unless defined?(Ractor.current)
+end

--- a/lib/backports/ractor/cloner.rb
+++ b/lib/backports/ractor/cloner.rb
@@ -1,0 +1,91 @@
+require_relative '../2.4.0/hash/transform_values'
+require_relative '../2.5.0/hash/transform_keys'
+
+class Ractor
+  module Cloner
+    extend self
+
+    def deep_clone(obj)
+      return obj if Ractor.ractor_shareable_self?(obj, false) { false }
+
+      @processed = {}.compare_by_identity
+      @changed = nil
+      result = process(obj) do |r|
+        copy_contents(r)
+      end
+      return result if result
+
+      Ractor.ractor_mark_set_shareable(@processed)
+      obj
+    end
+
+    # Yields a deep copy.
+    # If no deep copy is needed, `obj` is returned and
+    # nothing is yielded
+    private def clone_deeper(obj)
+      return obj if Ractor.ractor_shareable_self?(obj, false) { false }
+
+      result = process(obj) do |r|
+        copy_contents(r)
+      end
+      return obj unless result
+
+      yield result if block_given?
+      result
+    end
+
+    # Yields if `obj` is a new structure
+    # Returns the deep copy, or `false` if no deep copy is needed
+    private def process(obj)
+      @processed.fetch(obj) do
+        # For recursive structures, assume that we'll need a duplicate.
+        # If that's not the case, we will have duplicated the whole structure
+        # for nothing...
+        @processed[obj] = result = obj.dup
+        changed = track_change { yield result }
+        return false if obj.frozen? && !changed
+
+        @changed = true
+        result.freeze if obj.frozen?
+
+        result
+      end
+    end
+
+    # returns if the block called `deep clone` and that the deep copy was needed
+    private def track_change
+      prev = @changed
+      @changed = false
+      yield
+      @changed
+    ensure
+      @changed = prev
+    end
+
+    # modifies in place `obj` by calling `deep clone` on its contents
+    private def copy_contents(obj)
+      case obj
+      when ::Hash
+        if obj.default
+          clone_deeper(obj.default) do |copy|
+            obj.default = copy
+          end
+        end
+        obj.transform_keys! { |key| clone_deeper(key) }
+        obj.transform_values! { |value| clone_deeper(value) }
+      when ::Array
+        obj.map! { |item| clone_deeper(item) }
+      when ::Struct
+        obj.each_pair do |key, item|
+          clone_deeper(item) { |copy| obj[key] = copy }
+        end
+      end
+      obj.instance_variables.each do |var|
+        clone_deeper(obj.instance_variable_get(var)) do |copy|
+          obj.instance_variable_set(var, copy)
+        end
+      end
+    end
+  end
+  private_constant :Cloner
+end

--- a/lib/backports/ractor/errors.rb
+++ b/lib/backports/ractor/errors.rb
@@ -1,0 +1,16 @@
+class Ractor
+  class ClosedError < ::StopIteration
+  end
+
+  class Error < ::StandardError
+  end
+
+  class RemoteError < Error
+    attr_reader :ractor
+
+    def initialize(message = nil)
+      @ractor = Ractor.current
+      super
+    end
+  end
+end

--- a/lib/backports/ractor/queues.rb
+++ b/lib/backports/ractor/queues.rb
@@ -1,0 +1,62 @@
+require_relative '../tools/filtered_queue'
+
+class Ractor
+  # Standard ::Queue but raises if popping and closed
+  class BaseQueue < ::Backports::FilteredQueue
+    ClosedQueueError = ::Ractor::ClosedError
+
+    # yields message (if any)
+    def pop_non_blocking
+      yield pop(timeout: 0)
+    rescue TimeoutError
+      nil
+    end
+  end
+
+  class IncomingQueue < BaseQueue
+    TYPE = :incoming
+
+    protected def reenter
+      raise ::Ractor::Error, 'Can not reenter'
+    end
+  end
+
+  # * Wraps exception
+  # * Add `ack: ` to push (blocking)
+  class OutgoingQueue < BaseQueue
+    TYPE = :outgoing
+
+    WrappedException = ::Struct.new(:exception, :ractor)
+
+    def initialize
+      @ack_queue = ::Queue.new
+      super
+    end
+
+    def pop(timeout: nil, ack: true)
+      r = super(timeout: timeout)
+      @ack_queue << :done if ack
+      raise r.exception if WrappedException === r
+
+      r
+    end
+
+    def close(how = :hard)
+      super()
+      return if how == :soft
+
+      clear
+      @ack_queue.close
+    end
+
+    def push(obj, ack:)
+      super(obj)
+      if ack
+        r = @ack_queue.pop # block until popped
+        raise ClosedError, "The #{self.class::TYPE}-port is already closed" unless r == :done
+      end
+      self
+    end
+  end
+  private_constant :BaseQueue, :OutgoingQueue, :IncomingQueue
+end

--- a/lib/backports/ractor/ractor.rb
+++ b/lib/backports/ractor/ractor.rb
@@ -1,0 +1,238 @@
+# Ruby 2.0+ backport of `Ractor` class
+# Extra private methods and instance variables all start with `ractor_`
+class Ractor
+  require_relative '../tools/arguments'
+
+  require_relative 'cloner'
+  require_relative 'errors'
+  require_relative 'queues'
+  require_relative 'sharing'
+
+  # Implementation notes
+  #
+  # Uses one `Thread` for each `Ractor`, as well as queues for communication
+  #
+  # The incoming queue is strict: contrary to standard queue, you can't pop from an empty closed queue.
+  # Since standard queues return `nil` is those conditions, we wrap/unwrap `nil` values and consider
+  # all `nil` values to be results of closed queues. `ClosedQueueError` are re-raised as `Ractor::ClosedError`
+  #
+  # The outgoing queue is strict and blocking. Same wrapping / raising as incoming,
+  # with an extra queue to acknowledge when a value has been read (or if the port is closed while waiting).
+  #
+  # The last result is a bit tricky as it needs to be pushed on the outgoing queue but can not be blocking.
+  # For this, we "soft close" the outgoing port.
+
+  def initialize(*args, &block)
+    @ractor_incoming_queue = IncomingQueue.new
+    @ractor_outgoing_queue = OutgoingQueue.new
+    raise ArgumentError, 'must be called with a block' unless block
+
+    kw = args.last
+    if kw.is_a?(Hash) && kw.size == 1 && kw.key?(:name)
+      args.pop
+      name = kw[:name]
+    end
+    @ractor_name = name && Backports.coerce_to_str(name)
+
+    if Ractor.main == nil # then initializing main Ractor
+      @ractor_thread = ::Thread.current
+      @ractor_origin = nil
+      @ractor_thread.thread_variable_set(:ractor, self)
+    else
+      @ractor_origin = caller(1, 1).first.split(':in `').first
+
+      args.map! { |a| Ractor.ractor_isolate(a, false) }
+      ractor_thread_start(args, block)
+    end
+  end
+
+  private def ractor_thread_start(args, block)
+    Thread.new do
+      @ractor_thread = Thread.current
+      @ractor_thread_group = ThreadGroup.new.add(@ractor_thread)
+      ::Thread.current.thread_variable_set(:ractor, self)
+      result = nil
+      begin
+        result = instance_exec(*args, &block)
+      rescue ::Exception => err # rubocop:disable Lint/RescueException
+        begin
+          raise RemoteError, "thrown by remote Ractor: #{err.message}"
+        rescue RemoteError => e # Hack to create exception with `cause`
+          result = OutgoingQueue::WrappedException.new(e)
+        end
+      ensure
+        ractor_thread_terminate(result)
+      end
+    end
+  end
+
+  private def ractor_thread_terminate(result)
+    begin
+      ractor_outgoing_queue.push(result, ack: false) unless ractor_outgoing_queue.closed?
+    rescue ClosedQueueError
+      return # ignore
+    end
+    ractor_incoming_queue.close
+    ractor_outgoing_queue.close(:soft)
+  ensure
+    # TODO: synchronize?
+    @ractor_thread_group.list.each do |thread|
+      thread.kill unless thread == Thread.current
+    end
+  end
+
+  def send(obj, move: false)
+    ractor_incoming_queue << Ractor.ractor_isolate(obj, move)
+    self
+  rescue ::ClosedQueueError
+    raise ClosedError, 'The incoming-port is already closed'
+  end
+  alias_method :<<, :send
+
+  def take
+    ractor_outgoing_queue.pop(ack: true)
+  end
+
+  def name
+    @ractor_name
+  end
+
+  RACTOR_STATE = {
+    'sleep' => 'blocking',
+    'run' => 'running',
+    'aborting' => 'aborting',
+    false => 'terminated',
+    nil => 'terminated',
+  }.freeze
+  private_constant :RACTOR_STATE
+
+  def inspect
+    state = RACTOR_STATE[@ractor_thread ? @ractor_thread.status : 'run']
+    info = [
+      'Ractor:#1',
+      name,
+      @ractor_origin,
+      state
+    ].compact.join(' ')
+
+    "#<#{info}>"
+  end
+
+  def close_incoming
+    r = ractor_incoming_queue.closed?
+    ractor_incoming_queue.close
+    r
+  end
+
+  def close_outgoing
+    r = ractor_outgoing_queue.closed?
+    ractor_outgoing_queue.close
+    r
+  end
+
+  private def receive
+    ractor_incoming_queue.pop
+  end
+
+  private def receive_if(&block)
+    raise ArgumentError, 'no block given' unless block
+    ractor_incoming_queue.pop(&block)
+  end
+
+  class << self
+    def yield(value, move: false)
+      value = ractor_isolate(value, move)
+      current.ractor_outgoing_queue.push(value, ack: true)
+    rescue ClosedQueueError
+      raise ClosedError, 'The outgoing-port is already closed'
+    end
+
+    def receive
+      current.__send__(:receive)
+    end
+    alias_method :recv, :receive
+
+    def receive_if(&block)
+      current.__send__(:receive_if, &block)
+    end
+
+    def select(*ractors, yield_value: not_given = true, move: false)
+      cur = Ractor.current
+      queues = ractors.map do |r|
+        r == cur ? r.ractor_incoming_queue : r.ractor_outgoing_queue
+      end
+      if !not_given
+        out = current.ractor_outgoing_queue
+        yield_value = ractor_isolate(yield_value, move)
+      elsif ractors.empty?
+        raise ArgumentError, 'specify at least one ractor or `yield_value`'
+      end
+
+      while true # rubocop:disable Style/InfiniteLoop
+                  # Don't `loop`, in case of `ClosedError` (not that there should be any)
+        queues.each_with_index do |q, i|
+          q.pop_non_blocking do |val|
+            r = ractors[i]
+            return [r == cur ? :receive : r, val]
+          end
+        end
+
+        if out && out.num_waiting > 0
+          # Not quite atomic...
+          out.push(yield_value, ack: true)
+          return [:yield, nil]
+        end
+
+        sleep(0.001)
+      end
+    end
+
+    def make_shareable(obj)
+      return obj if ractor_check_shareability?(obj, true)
+
+      raise Ractor::Error, '#freeze does not freeze object correctly'
+    end
+
+    def shareable?(obj)
+      ractor_check_shareability?(obj, false)
+    end
+
+    def current
+      Thread.current.thread_variable_get(:ractor)
+    end
+
+    def count
+      ObjectSpace.each_object(Ractor).count(&:ractor_live?)
+    end
+
+    # @api private
+    def ractor_reset
+      ObjectSpace.each_object(Ractor).each do |r|
+        next if r == Ractor.current
+        next unless (th = r.ractor_thread)
+
+        th.kill
+        th.join
+      end
+      Ractor.current.ractor_incoming_queue.clear
+    end
+
+    attr_reader :main
+
+    private def ractor_init
+      @ractor_shareable = ::ObjectSpace::WeakMap.new
+      @main = Ractor.new { nil }
+    end
+  end
+
+  # @api private
+  def ractor_live?
+    !defined?(@ractor_thread) || # May happen if `count` is called from another thread before `initialize` has completed
+      @ractor_thread.status
+  end
+
+  # @api private
+  attr_reader :ractor_outgoing_queue, :ractor_incoming_queue, :ractor_thread
+
+  ractor_init
+end

--- a/lib/backports/ractor/sharing.rb
+++ b/lib/backports/ractor/sharing.rb
@@ -1,0 +1,93 @@
+class Ractor
+  class << self
+    # @api private
+    def ractor_isolate(val, move = false)
+      return val if move
+
+      Cloner.deep_clone(val)
+    end
+
+    private def ractor_check_shareability?(obj, freeze_all)
+      ractor_shareable_self?(obj, freeze_all) do
+        visited = {}
+
+        return false unless ractor_shareable_parts?(obj, freeze_all, visited)
+
+        ractor_mark_set_shareable(visited)
+
+        true
+      end
+    end
+
+    # yield if shareability can't be determined without looking at its parts
+    def ractor_shareable_self?(obj, freeze_all)
+      return true if @ractor_shareable.key?(obj)
+      return true if ractor_shareable_by_nature?(obj, freeze_all)
+      if obj.frozen? || (freeze_all && obj.freeze)
+        yield
+      else
+        false
+      end
+    end
+
+    private def ractor_shareable_parts?(obj, freeze_all, visited)
+      return true if visited.key?(obj)
+      visited[obj] = true
+
+      ractor_traverse(obj) do |part|
+        return false unless ractor_shareable_self?(part, freeze_all) do
+          ractor_shareable_parts?(part, freeze_all, visited)
+        end
+      end
+
+      true
+    end
+
+    def ractor_mark_set_shareable(visited)
+      visited.each do |key|
+        @ractor_shareable[key] = Ractor
+      end
+    end
+
+    private def ractor_traverse(obj, &block)
+      case obj
+      when ::Hash
+        Hash obj.default
+        yield obj.default_proc
+        obj.each do |key, value|
+          yield key
+          yield value
+        end
+      when ::Range
+        yield obj.begin
+        yield obj.end
+      when ::Array, ::Struct
+        obj.each(&block)
+      when ::Complex
+        yield obj.real
+        yield obj.imaginary
+      when ::Rational
+        yield obj.numerator
+        yield obj.denominator
+      end
+      obj.instance_variables.each do |var|
+        yield obj.instance_variable_get(var)
+      end
+    end
+
+    private def ractor_shareable_by_nature?(obj, freeze_all)
+      case obj
+      when ::Module, ::Ractor
+        true
+      when ::Regexp, ::Range, ::Numeric
+        !freeze_all # Assume that these are literals that would have been frozen in 3.0
+                    # unless we're making them shareable, in which case we might as well
+                    # freeze them for real.
+      when ::Symbol, false, true, nil # Were only frozen in Ruby 2.3+
+        true
+      else
+        false
+      end
+    end
+  end
+end

--- a/lib/backports/tools/filtered_queue.rb
+++ b/lib/backports/tools/filtered_queue.rb
@@ -1,0 +1,202 @@
+module Backports
+  class FilteredQueue
+    require 'backports/2.3.0/queue/close'
+    CONSUME_ON_ESCAPE = true
+
+    class ClosedQueueError < ::ClosedQueueError
+    end
+    class TimeoutError < ::ThreadError
+    end
+
+    class Message
+      # Not using Struct as we want comparision by identity
+      attr_reader :value
+      attr_accessor :reserved
+
+      def initialize(value)
+        @value = value
+        @reserved = false
+      end
+    end
+    private_constant :Message
+
+    # Like ::Queue, but with
+    # - filtering
+    # - timeout
+    # - raises on closed queues
+
+    attr_reader :num_waiting
+
+    # Timeout processing based on https://spin.atomicobject.com/2017/06/28/queue-pop-with-timeout-fixed/
+    def initialize
+      @mutex = ::Mutex.new
+      @queue = []
+      @closed = false
+      @received = ::ConditionVariable.new
+      @num_waiting = 0
+    end
+
+    def close
+      @mutex.synchronize do
+        @closed = true
+        @received.broadcast
+      end
+      self
+    end
+
+    def closed?
+      @closed
+    end
+
+    def <<(x)
+      @mutex.synchronize do
+        ensure_open
+        @queue << Message.new(x)
+        @received.signal
+      end
+      self
+    end
+    alias_method :push, :<<
+
+    def clear
+      @mutex.synchronize do
+        @queue.clear
+      end
+      self
+    end
+
+    def pop(timeout: nil, &block)
+      msg = nil
+      exclude = [] if block # exclusion list of messages rejected by this call
+      timeout_time = timeout + Time.now.to_f if timeout
+      while true do
+        @mutex.synchronize do
+          reenter if reentrant?
+          msg = acquire!(timeout_time, exclude)
+          return consume!(msg).value unless block
+        end
+        return msg.value if filter?(msg, &block)
+      end
+    end
+
+    def empty?
+      avail = @mutex.synchronize do
+        available!
+      end
+
+      !avail
+    end
+
+    protected def timeout_value
+      raise self.class::TimeoutError, "timeout elapsed"
+    end
+
+    protected def closed_queue_value
+      ensure_open
+    end
+
+    # @return if outer message should be consumed or not
+    protected def reenter
+      true
+    end
+
+    ### private section
+    #
+    # bang methods require synchronization
+
+    # @returns:
+    # * true if message consumed (block result truthy or due to reentrant call)
+    # * false if rejected
+    private def filter?(msg)
+      consume = self.class::CONSUME_ON_ESCAPE
+      begin
+        reentered = consume_on_reentry(msg) do
+          consume = !!(yield msg.value)
+        end
+        reentered ? reenter : consume
+      ensure
+        commit(msg, consume) unless reentered
+      end
+    end
+
+    # @returns msg
+    private def consume!(msg)
+      @queue.delete(msg)
+    end
+
+    private def reject!(msg)
+      msg.reserved = false
+      @received.broadcast
+    end
+
+    private def commit(msg, consume)
+      @mutex.synchronize do
+        if consume
+          consume!(msg)
+        else
+          reject!(msg)
+        end
+      end
+    end
+
+    private def consume_on_reentry(msg)
+      q_map = current_filtered_queues
+      if (outer_msg = q_map[self])
+        commit(outer_msg, reenter)
+      end
+      q_map[self] = msg
+      begin
+        yield
+      ensure
+        reentered = !q_map.delete(self)
+      end
+      reentered
+    end
+
+    private def reentrant?
+      !!current_filtered_queues[self]
+    end
+
+    # @returns Hash { FilteredQueue => Message }
+    private def current_filtered_queues
+      t = Thread.current
+      t.thread_variable_get(:backports_currently_filtered_queues) or
+        t.thread_variable_set(:backports_currently_filtered_queues, {}.compare_by_identity)
+    end
+
+    # private methods assume @mutex synchonized
+    # adds to exclude list
+    private def acquire!(timeout_time, exclude = nil)
+      while true do
+        if (msg = available!(exclude))
+          msg.reserved = true
+          exclude << msg if exclude
+          return msg
+        end
+        return closed_queue_value if @closed
+        # wait for element or timeout
+        if timeout_time
+          remaining_time = timeout_time - ::Time.now.to_f
+          return timeout_value if remaining_time <= 0
+        end
+        begin
+          @num_waiting += 1
+          @received.wait(@mutex, remaining_time)
+        ensure
+          @num_waiting -= 1
+        end
+      end
+    end
+
+    private def available!(exclude = nil)
+      @queue.find do |msg|
+        next if exclude && exclude.include?(msg)
+        !msg.reserved
+      end
+    end
+
+    private def ensure_open
+      raise self.class::ClosedQueueError, 'queue closed' if @closed
+    end
+  end
+end

--- a/test/filtered_queue_test.rb
+++ b/test/filtered_queue_test.rb
@@ -1,0 +1,102 @@
+require './test/test_helper'
+require 'backports/tools/filtered_queue'
+
+class FilteredQueueTest < Test::Unit::TestCase
+  def setup
+    @q = ::Backports::FilteredQueue.new
+  end
+
+  def assert_remains(*values)
+    remain = []
+    remain << @q.pop until @q.empty?
+    assert_equal values, remain
+  end
+
+  def test_basic
+    @q << 1 << 2
+    x = []
+    x << @q.pop
+    @q << 3
+    x << @q.pop
+    x << @q.pop
+    t = Thread.new { sleep(0.1); @q << 4 << 5}
+    x << @q.pop
+    t.join
+    assert_equal([1,2,3,4], x)
+    assert_remains(5)
+  end
+
+  def test_close
+    Thread.new { sleep(0.2); @q.close }
+    assert_raise(::Backports::FilteredQueue::ClosedQueueError) { @q.pop }
+    assert_raise(::Backports::FilteredQueue::ClosedQueueError) { @q.pop }
+    assert_raise(::Backports::FilteredQueue::ClosedQueueError) { @q.pop(timeout: 0) }
+    assert_raise(::Backports::FilteredQueue::ClosedQueueError) { @q << 42 }
+  end
+
+  def test_close_after
+    @q << 1 << 2
+    @q.close
+    assert_equal(1, @q.pop)
+    assert_equal(2, @q.pop)
+    assert_raise(::Backports::FilteredQueue::ClosedQueueError) { @q.pop }
+  end
+
+  def test_timeout
+    assert_raise(::Backports::FilteredQueue::TimeoutError) { @q.pop(timeout: 0) }
+    Thread.new { sleep(0.2); @q << :done }
+    assert_raise(::Backports::FilteredQueue::TimeoutError) { @q.pop(timeout: 0.1) }
+    assert_equal(:done, @q.pop(timeout: 0.2))
+  end
+
+  def test_filter
+    # send 0 to 7 to queue, with filters for 0 to 2.
+    # start queue with `before` elements already present
+    (0..4).each do |before|
+      other = [4,5,6,7]
+      calls = 0
+      before.times { @q << other.shift }
+      t = 3.times.map do |i|
+        Thread.new do
+          @q.pop { |n| calls += 1; Thread.pass; n == i }
+        end
+      end
+      Thread.pass
+      other.each { |i| @q << i }
+      sleep(0.1)
+      assert_equal 3, @q.num_waiting
+      assert_equal 3 * 4, calls
+      @q << :extra
+      sleep(0.1)
+      assert_equal 3 * 5, calls
+      @q << 0 << 1 << 2 << 3
+      t.each(&:join)
+      assert_equal 0, @q.num_waiting
+      assert_remains 4, 5, 6, 7, :extra, 3
+    end
+  end
+
+  def test_non_standard_filters
+    @q << 1 << 2 << 3
+    @q.pop { break }
+    @q.pop { raise 'err' } rescue nil
+    assert_remains 3
+  end
+
+  def test_recursive_filter
+    [
+      [0, :other],
+      [:other, 0],
+    ].each do |a, b|
+      @q << :first << a << b << :last
+      inner = nil
+      a = @q.pop do
+        inner = @q.pop { |x| x == 0}
+        false # => ignored
+      end
+      assert_equal :first, a
+      assert_equal 0, inner
+      assert_remains :other, :last
+    end
+  end
+end

--- a/test/mri_runner.rb
+++ b/test/mri_runner.rb
@@ -1,0 +1,480 @@
+# Adapted from MRI's bootstraptest/runner
+
+def main
+  # @ruby = File.expand_path('miniruby')
+  @ruby = nil
+  @verbose = false
+  $VERBOSE = false
+  $stress = false
+  @color = nil
+  @tty = nil
+  @quiet = false
+  dir = nil
+  quiet = false
+  tests = nil
+#   ARGV.delete_if {|arg|
+#     case arg
+#     when /\A--ruby=(.*)/
+#       @ruby = $1
+#       @ruby.gsub!(/^([^ ]*)/){File.expand_path($1)}
+#       @ruby.gsub!(/(\s+-I\s*)((?!(?:\.\/)*-(?:\s|\z))\S+)/){$1+File.expand_path($2)}
+#       @ruby.gsub!(/(\s+-r\s*)(\.\.?\/\S+)/){$1+File.expand_path($2)}
+#       true
+#     when /\A--sets=(.*)/
+#       tests = Dir.glob("#{File.dirname($0)}/test_{#{$1}}*.rb").sort
+#       puts tests.map {|path| File.basename(path) }.inspect
+#       true
+#     when /\A--dir=(.*)/
+#       dir = $1
+#       true
+#     when /\A(--stress|-s)/
+#       $stress = true
+#     when /\A--color(?:=(?:always|(auto)|(never)|(.*)))?\z/
+#       warn "unknown --color argument: #$3" if $3
+#       @color = $1 ? nil : !$2
+#       true
+#     when /\A--tty(=(?:yes|(no)|(.*)))?\z/
+#       warn "unknown --tty argument: #$3" if $3
+#       @tty = !$1 || !$2
+#       true
+#     when /\A(-q|--q(uiet))\z/
+#       quiet = true
+#       @quiet = true
+#       true
+#     when /\A(-v|--v(erbose))\z/
+#       @verbose = true
+#     when /\A(-h|--h(elp)?)\z/
+#       puts(<<-End)
+# Usage: #{File.basename($0, '.*')} --ruby=PATH [--sets=NAME,NAME,...]
+#         --sets=NAME,NAME,...        Name of test sets.
+#         --dir=DIRECTORY             Working directory.
+#                                     default: /tmp/bootstraptestXXXXX.tmpwd
+#         --color[=WHEN]              Colorize the output.  WHEN defaults to 'always'
+#                                     or can be 'never' or 'auto'.
+#     -s, --stress                    stress test.
+#     -v, --verbose                   Output test name before exec.
+#     -q, --quiet                     Don\'t print header message.
+#     -h, --help                      Print this message and quit.
+# End
+#       exit true
+#     when /\A-j/
+#       true
+#     else
+#       false
+#     end
+#   }
+  # if tests and not ARGV.empty?
+  #   $stderr.puts "--tests and arguments are exclusive"
+  #   exit false
+  # end
+  # tests ||= ARGV
+  # tests = Dir.glob("#{File.dirname($0)}/test_*.rb").sort if tests.empty?
+  # pathes = tests.map {|path| File.expand_path(path) }
+
+  @progress = %w[- \\ | /]
+  @progress_bs = "\b" * @progress[0].size
+  @tty = $stderr.tty? if @tty.nil?
+  case @color
+  when nil
+    @color = @tty && /dumb/ !~ ENV["TERM"]
+  end
+  @tty &&= !@verbose
+  if @color
+    # dircolors-like style
+    colors = (colors = ENV['TEST_COLORS']) ? Hash[colors.scan(/(\w+)=([^:\n]*)/)] : {}
+    begin
+      File.read(File.join(__dir__, "../tool/colors")).scan(/(\w+)=([^:\n]*)/) do |n, c|
+        colors[n] ||= c
+      end
+    rescue
+    end
+    @passed = "\e[;#{colors["pass"] || "32"}m"
+    @failed = "\e[;#{colors["fail"] || "31"}m"
+    @reset = "\e[m"
+  else
+    @passed = @failed = @reset = ""
+  end
+  # unless quiet
+  #   puts Time.now
+  #   if defined?(RUBY_DESCRIPTION)
+  #     puts "Driver is #{RUBY_DESCRIPTION}"
+  #   elsif defined?(RUBY_PATCHLEVEL)
+  #     puts "Driver is ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE}#{RUBY_PLATFORM}) [#{RUBY_PLATFORM}]"
+  #   else
+  #     puts "Driver is ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE}) [#{RUBY_PLATFORM}]"
+  #   end
+  #   puts "Target is #{`#{@ruby} -v`.chomp}"
+  #   puts
+  #   $stdout.flush
+  # end
+
+  # in_temporary_working_directory(dir) {
+  #   exec_test pathes
+  # }
+end
+
+def erase(e = true)
+  if e and @columns > 0 and @tty and !@verbose
+    "\e[1K\r"
+  else
+    ""
+  end
+end
+
+def exec_test(pathes)
+  @count = 0
+  @error = 0
+  @errbuf = []
+  @location = nil
+  @columns = 0
+  @width = pathes.map {|path| File.basename(path).size}.max + 2
+  pathes.each do |path|
+    @basename = File.basename(path)
+    $stderr.printf("%s%-*s ", erase(@quiet), @width, @basename)
+    $stderr.flush
+    @columns = @width + 1
+    $stderr.puts if @verbose
+    count = @count
+    error = @error
+    load File.expand_path(path)
+    if @tty
+      if @error == error
+        msg = "PASS #{@count-count}"
+        @columns += msg.size - 1
+        $stderr.print "#{@progress_bs}#{@passed}#{msg}#{@reset}"
+      else
+        msg = "FAIL #{@error-error}/#{@count-count}"
+        $stderr.print "#{@progress_bs}#{@failed}#{msg}#{@reset}"
+        @columns = 0
+      end
+    end
+    $stderr.puts unless @quiet and @tty and @error == error
+  end
+  $stderr.print(erase) if @quiet
+  @errbuf.each do |msg|
+    $stderr.puts msg
+  end
+  if @error == 0
+    if @count == 0
+      $stderr.puts "No tests, no problem"
+    else
+      $stderr.puts "#{@passed}PASS#{@reset} all #{@count} tests"
+    end
+    exit true
+  else
+    $stderr.puts "#{@failed}FAIL#{@reset} #{@error}/#{@count} tests failed"
+    exit false
+  end
+end
+
+def show_progress(message = '')
+  if @verbose
+    $stderr.print "\##{@count} #{@location} "
+  elsif @tty
+    $stderr.print "#{@progress_bs}#{@progress[@count % @progress.size]}"
+  end
+  t = Time.now if @verbose
+  faildesc, errout = with_stderr {yield}
+  t = Time.now - t if @verbose
+  if !faildesc
+    if @tty
+      $stderr.print "#{@progress_bs}#{@progress[@count % @progress.size]}"
+    elsif @verbose
+      $stderr.printf(". %.3f\n", t)
+    else
+      $stderr.print '.'
+    end
+  else
+    $stderr.print "#{@failed}F"
+    $stderr.printf(" %.3f", t) if @verbose
+    $stderr.print @reset
+    $stderr.puts if @verbose
+    error faildesc, message
+    unless errout.empty?
+      $stderr.print "#{@failed}stderr output is not empty#{@reset}\n", adjust_indent(errout)
+    end
+    if @tty and !@verbose
+      $stderr.printf("%-*s%s", @width, @basename, @progress[@count % @progress.size])
+    end
+  end
+rescue Interrupt
+  $stderr.puts "\##{@count} #{@location}"
+  raise
+rescue Exception => err
+  $stderr.print 'E'
+  $stderr.puts if @verbose
+  error err.message, message, err.backtrace
+ensure
+  begin
+    check_coredump
+  rescue CoreDumpError => err
+    $stderr.print 'E'
+    $stderr.puts if @verbose
+    error err.message, message
+  end
+end
+
+def show_limit(testsrc, opt = '', **argh)
+  result = get_result_string(testsrc, opt, **argh)
+  if @tty and @verbose
+    $stderr.puts ".{#@reset}\n#{erase}#{result}"
+  else
+    @errbuf.push result
+  end
+end
+
+def assert_check(testsrc, message = '', opt = '', **argh)
+  show_progress(message) {
+    result = get_result_string(testsrc, opt, **argh)
+    yield(result)
+  }
+end
+
+def assert_equal(expected, testsrc, message = '', opt = '', **argh)
+  newtest
+  assert_check(testsrc, message, opt, **argh) {|result|
+    if expected == result
+      nil
+    else
+      desc = "#{result.inspect} (expected #{expected.inspect})"
+      pretty(testsrc, desc, result)
+    end
+  }
+end
+
+def assert_match(expected_pattern, testsrc, message = '')
+  newtest
+  assert_check(testsrc, message) {|result|
+    if expected_pattern =~ result
+      nil
+    else
+      desc = "#{expected_pattern.inspect} expected to be =~\n#{result.inspect}"
+      pretty(testsrc, desc, result)
+    end
+  }
+end
+
+def assert_not_match(unexpected_pattern, testsrc, message = '')
+  newtest
+  assert_check(testsrc, message) {|result|
+    if unexpected_pattern !~ result
+      nil
+    else
+      desc = "#{unexpected_pattern.inspect} expected to be !~\n#{result.inspect}"
+      pretty(testsrc, desc, result)
+    end
+  }
+end
+
+def assert_valid_syntax(testsrc, message = '')
+  newtest
+  assert_check(testsrc, message, '-c') {|result|
+    result if /Syntax OK/ !~ result
+  }
+end
+
+def assert_normal_exit(testsrc, *rest, timeout: nil, **opt)
+  newtest
+  message, ignore_signals = rest
+  message ||= ''
+  show_progress(message) {
+    faildesc = nil
+    filename = make_srcfile(testsrc)
+    old_stderr = $stderr.dup
+    timeout_signaled = false
+    begin
+      $stderr.reopen("assert_normal_exit.log", "w")
+      io = IO.popen("#{@ruby} -W0 #{filename}")
+      pid = io.pid
+      th = Thread.new {
+        io.read
+        io.close
+        $?
+      }
+      if !th.join(timeout)
+        Process.kill :KILL, pid
+        timeout_signaled = true
+      end
+      status = th.value
+    ensure
+      $stderr.reopen(old_stderr)
+      old_stderr.close
+    end
+    if status && status.signaled?
+      signo = status.termsig
+      signame = Signal.list.invert[signo]
+      unless ignore_signals and ignore_signals.include?(signame)
+        sigdesc = "signal #{signo}"
+        if signame
+          sigdesc = "SIG#{signame} (#{sigdesc})"
+        end
+        if timeout_signaled
+          sigdesc << " (timeout)"
+        end
+        faildesc = pretty(testsrc, "killed by #{sigdesc}", nil)
+        stderr_log = File.read("assert_normal_exit.log")
+        if !stderr_log.empty?
+          faildesc << "\n" if /\n\z/ !~ faildesc
+          stderr_log << "\n" if /\n\z/ !~ stderr_log
+          stderr_log.gsub!(/^.*\n/) { '| ' + $& }
+          faildesc << stderr_log
+        end
+      end
+    end
+    faildesc
+  }
+end
+
+def assert_finish(timeout_seconds, testsrc, message = '')
+  if RubyVM.const_defined? :MJIT
+    timeout_seconds *= 3 if RubyVM::MJIT.enabled? # for --jit-wait
+  end
+  newtest
+  show_progress(message) {
+    faildesc = nil
+    filename = make_srcfile(testsrc)
+    io = IO.popen("#{@ruby} -W0 #{filename}")
+    pid = io.pid
+    waited = false
+    tlimit = Time.now + timeout_seconds
+    diff = timeout_seconds
+    while diff > 0
+      if Process.waitpid pid, Process::WNOHANG
+        waited = true
+        break
+      end
+      if io.respond_to?(:read_nonblock)
+        if IO.select([io], nil, nil, diff)
+          begin
+            io.read_nonblock(1024)
+          rescue Errno::EAGAIN, IO::WaitReadable, EOFError
+            break
+          end while true
+        end
+      else
+        sleep 0.1
+      end
+      diff = tlimit - Time.now
+    end
+    if !waited
+      Process.kill(:KILL, pid)
+      Process.waitpid pid
+      faildesc = pretty(testsrc, "not finished in #{timeout_seconds} seconds", nil)
+    end
+    io.close
+    faildesc
+  }
+end
+
+def flunk(message = '')
+  newtest
+  show_progress('') { message }
+end
+
+def pretty(src, desc, result)
+  src = src.sub(/\A\s*\n/, '')
+  (/\n/ =~ src ? "\n#{adjust_indent(src)}" : src) + "  #=> #{desc}"
+end
+
+INDENT = 27
+
+def adjust_indent(src)
+  untabify(src).gsub(/^ {#{INDENT}}/o, '').gsub(/^/, '   ').sub(/\s*\z/, "\n")
+end
+
+def untabify(str)
+  str.gsub(/^\t+/) {' ' * (8 * $&.size) }
+end
+
+def make_srcfile(src, frozen_string_literal: nil)
+  filename = 'bootstraptest.tmp.rb'
+  File.open(filename, 'w') {|f|
+    f.puts "#frozen_string_literal:true" if frozen_string_literal
+    f.puts "GC.stress = true" if $stress
+    f.puts "print(begin; #{src}; end)"
+  }
+  filename
+end
+
+def get_result_string(src, opt = '', **argh)
+  if @ruby
+    filename = make_srcfile(src, **argh)
+    begin
+      `#{@ruby} -W0 #{opt} #{filename}`
+    ensure
+      raise Interrupt if $? and $?.signaled? && $?.termsig == Signal.list["INT"]
+    end
+  else
+    eval(src).to_s
+  end
+end
+
+def with_stderr
+  out = err = nil
+  begin
+    r, w = IO.pipe
+    stderr = $stderr.dup
+    $stderr.reopen(w)
+    w.close
+    reader = Thread.start {r.read}
+    begin
+      out = yield
+    ensure
+      $stderr.reopen(stderr)
+      err = reader.value
+    end
+  ensure
+    w.close rescue nil
+    r.close rescue nil
+  end
+  return out, err
+end
+
+def newtest
+  @location = File.basename(caller(2).first)
+  @count += 1
+  #cleanup_coredump
+end
+
+def error(msg, additional_message, backtrace = nil)
+  msg = "#{@failed}\##{@count} #{@location}#{@reset}: #{msg}  #{additional_message}"
+  msg << backtrace.join("\n") if backtrace
+  if @tty
+    $stderr.puts "#{erase}#{msg}"
+  else
+    @errbuf.push msg
+  end
+  @error += 1
+end
+
+def in_temporary_working_directory(dir)
+  if dir
+    Dir.mkdir dir
+    Dir.chdir(dir) {
+      yield
+    }
+  else
+    Dir.mktmpdir(["bootstraptest", ".tmpwd"]) {|d|
+      Dir.chdir(d) {
+        yield
+      }
+    }
+  end
+end
+
+def cleanup_coredump
+  FileUtils.rm_f 'core'
+  FileUtils.rm_f Dir.glob('core.*')
+  FileUtils.rm_f @ruby+'.stackdump' if @ruby
+end
+
+class CoreDumpError < StandardError; end
+
+def check_coredump
+  # if File.file?('core') or not Dir.glob('core.*').empty? or
+  #     (@ruby and File.exist?(@ruby+'.stackdump'))
+  #   raise CoreDumpError, "core dumped"
+  # end
+end
+
+main

--- a/test/mri_runner_patched.rb
+++ b/test/mri_runner_patched.rb
@@ -1,0 +1,36 @@
+require './test/mri_runner'
+
+if Ractor.respond_to? :ractor_reset
+
+  SKIP = [
+    'touching moved object causes an error',
+    'move example2: Array',
+    'move with yield',
+    'Access to global-variables are prohibited',
+    '$stdin,out,err is Ractor local, but shared fds',
+    'given block Proc will be isolated, so can not access outer variables.',
+    'ivar in shareable-objects are not allowed to access from non-main Ractor',
+    'cvar in shareable-objects are not allowed to access from non-main Ractor',
+    'Getting non-shareable objects via constants by other Ractors is not allowed',
+    'Setting non-shareable objects into constants by other Ractors is not allowed',
+    'define_method is not allowed',
+    'ObjectSpace.each_object can not handle unshareable objects with Ractors',
+    'ObjectSpace._id2ref can not handle unshareable objects with Ractors',
+    'ivar in shareable-objects are not allowed to access from non-main Ractor, by @iv (set)',
+    'ivar in shareable-objects are not allowed to access from non-main Ractor, by @iv (get)',
+    'Can not trap with not isolated Proc on non-main ractor',
+    'Ractor.make_shareable(a_proc) makes a proc shareable',
+    "define_method() can invoke different Ractor's proc if the proc is shareable.", # :-(
+    'Ractor.make_shareable(a_proc) makes a proc shareable.',
+    #*('Ractor.count' if RUBY_VERSION < '2.2')
+  ].freeze
+
+  alias show_progress_org show_progress
+  def show_progress(m='', &b)
+    _path, line = @location.split(':')
+    comment = File.read(PATH).lines[line.to_i-2][2...-1]
+    show_progress_org(m, &b) unless SKIP.include?(comment)
+    Ractor.ractor_reset
+  end
+
+end

--- a/test/ractor_extra_test.rb
+++ b/test/ractor_extra_test.rb
@@ -1,0 +1,59 @@
+require './test/test_helper'
+require './lib/backports/3.0.0/ractor.rb'
+
+class ExtraRactorTest < Test::Unit::TestCase
+  def assert_shareable(*objects)
+    check_shareability(objects, true)
+  end
+
+  def assert_not_shareable(*objects, &block)
+    check_shareability(objects, false)
+  end
+
+  def check_shareability(objects, shareable)
+    objects.each do |obj|
+      assert_equal shareable, obj.object_id == Ractor.new(obj, &:object_id).take
+      assert_equal shareable, obj.object_id == Ractor.new([obj]) { |x, | x.object_id }.take
+      assert_equal obj.frozen?, Ractor.new(obj, &:frozen?).take
+      assert_equal obj.frozen?, Ractor.new([obj]) { |x, | x.frozen? } .take
+      assert_equal shareable, Ractor.shareable?(obj)
+    end
+  end
+
+  def test_copy_only_copies_when_needed
+    r = Ractor.new {}
+    assert_shareable(r, 42, 4.2, 2..4, false, true, nil, 'abc'.freeze)
+
+    assert_not_shareable(+'abc', [], {})
+
+    a = []; b = [a].freeze; c = [a].freeze; a << c
+    assert_not_shareable(a, b, c)
+
+    a.freeze
+    assert_shareable(a, b, c)
+
+    h = {a: 1, b: 2}
+    assert_not_shareable(h)
+    assert_shareable(h.freeze)
+
+    h = {a: [1, 2, 3], b: 2}
+    assert_not_shareable(h)
+    assert_not_shareable(h.freeze)
+    h[:a].freeze
+    assert_shareable(h)
+  end
+
+  def make_shareable_fail
+    o = Object.new
+    def o.freeze; self; end
+    assert_raise(Ractor::Error) { Ractor.make_shareable(o) }
+  end
+
+  def test_main
+    assert_same(Ractor.current, Ractor.main)
+    r = Ractor.new { [Ractor.main, Ractor.current] }
+    main, current = r.take
+    assert_same(r, current)
+    assert_same(main, Ractor.main)
+  end
+end

--- a/test/ractor_test.rb
+++ b/test/ractor_test.rb
@@ -1,0 +1,14 @@
+if RUBY_VERSION < '3'
+  require './lib/backports/3.0.0/ractor.rb'
+  require './lib/backports/2.3.0/string/uminus.rb'
+
+  PATH = './test/test_ractor.rb'
+  require './test/mri_runner_patched.rb'
+
+  nil.freeze
+  true.freeze
+  false.freeze
+
+  exec_test [PATH]
+end
+

--- a/test/test_ractor.rb
+++ b/test/test_ractor.rb
@@ -1,0 +1,1272 @@
+# Copied, but:
+# - remove `all?`
+# - remove endless ranges
+# - wrap a rescue between `begin` `else` ~1246
+
+# Ractor.current returns a current ractor
+assert_equal 'Ractor', %q{
+  Ractor.current.class
+}
+
+# Ractor.new returns new Ractor
+assert_equal 'Ractor', %q{
+  Ractor.new{}.class
+}
+
+# A Ractor can have a name
+assert_equal 'test-name', %q{
+  r = Ractor.new name: 'test-name' do
+  end
+  r.name
+}
+
+# If Ractor doesn't have a name, Ractor#name returns nil.
+assert_equal 'nil', %q{
+  r = Ractor.new do
+  end
+  r.name.inspect
+}
+
+# Raises exceptions if initialize with an invalid name
+assert_equal 'ok', %q{
+  begin
+    r = Ractor.new(name: [{}]) {}
+  rescue TypeError => e
+    'ok'
+  end
+}
+
+# Ractor.new must call with a block
+assert_equal "must be called with a block", %q{
+  begin
+    Ractor.new
+  rescue ArgumentError => e
+    e.message
+  end
+}
+
+# Ractor#inspect
+# Return only id and status for main ractor
+assert_equal "#<Ractor:#1 running>", %q{
+  Ractor.current.inspect
+}
+
+# Return id, loc, and status for no-name ractor
+assert_match /^#<Ractor:#([^ ]*?) .+:[0-9]+ terminated>$/, %q{
+  r = Ractor.new { '' }
+  r.take
+  sleep 0.1 until r.inspect =~ /terminated/
+  r.inspect
+}
+
+# Return id, name, loc, and status for named ractor
+assert_match /^#<Ractor:#([^ ]*?) Test Ractor .+:[0-9]+ terminated>$/, %q{
+  r = Ractor.new(name: 'Test Ractor') { '' }
+  r.take
+  sleep 0.1 until r.inspect =~ /terminated/
+  r.inspect
+}
+
+# A return value of a Ractor block will be a message from the Ractor.
+assert_equal 'ok', %q{
+  # join
+  r = Ractor.new do
+    'ok'
+  end
+  r.take
+}
+
+# Passed arguments to Ractor.new will be a block parameter
+# The values are passed with Ractor-communication pass.
+assert_equal 'ok', %q{
+  # ping-pong with arg
+  r = Ractor.new 'ok' do |msg|
+    msg
+  end
+  r.take
+}
+
+# Pass multiple arguments to Ractor.new
+assert_equal 'ok', %q{
+  # ping-pong with two args
+  r =  Ractor.new 'ping', 'pong' do |msg, msg2|
+    [msg, msg2]
+  end
+  'ok' if r.take == ['ping', 'pong']
+}
+
+# Ractor#send passes an object with copy to a Ractor
+# and Ractor.receive in the Ractor block can receive the passed value.
+assert_equal 'ok', %q{
+  r = Ractor.new do
+    msg = Ractor.receive
+  end
+  r.send 'ok'
+  r.take
+}
+
+# Ractor#receive_if can filter the message
+assert_equal '[2, 3, 1]', %q{
+  r = Ractor.new Ractor.current do |main|
+    main << 1
+    main << 2
+    main << 3
+  end
+  a = []
+  a << Ractor.receive_if{|msg| msg == 2}
+  a << Ractor.receive_if{|msg| msg == 3}
+  a << Ractor.receive
+}
+
+# Ractor#receive_if with break
+assert_equal '[2, [1, :break], 3]', %q{
+  r = Ractor.new Ractor.current do |main|
+    main << 1
+    main << 2
+    main << 3
+  end
+
+  a = []
+  a << Ractor.receive_if{|msg| msg == 2}
+  a << Ractor.receive_if{|msg| break [msg, :break]}
+  a << Ractor.receive
+}
+
+# Ractor#receive_if can't be called recursively
+assert_equal '[[:e1, 1], [:e2, 2]]', %q{
+  r = Ractor.new Ractor.current do |main|
+    main << 1
+    main << 2
+    main << 3
+  end
+
+  a = []
+
+  Ractor.receive_if do |msg|
+    begin
+      Ractor.receive
+    rescue Ractor::Error
+      a << [:e1, msg]
+    end
+    true # delete 1 from queue
+  end
+
+  Ractor.receive_if do |msg|
+    begin
+      Ractor.receive_if{}
+    rescue Ractor::Error
+      a << [:e2, msg]
+    end
+    true # delete 2 from queue
+  end
+
+  a #
+}
+
+###
+###
+# Ractor still has several memory corruption so skip huge number of tests
+if ENV['GITHUB_WORKFLOW'] &&
+   ENV['GITHUB_WORKFLOW'] == 'Compilations'
+   # ignore the follow
+else
+
+# Ractor.select(*ractors) receives a values from a ractors.
+# It is similar to select(2) and Go's select syntax.
+# The return value is [ch, received_value]
+assert_equal 'ok', %q{
+  # select 1
+  r1 = Ractor.new{'r1'}
+  r, obj = Ractor.select(r1)
+  'ok' if r == r1 and obj == 'r1'
+}
+
+# Ractor.select from two ractors.
+assert_equal '["r1", "r2"]', %q{
+  # select 2
+  r1 = Ractor.new{'r1'}
+  r2 = Ractor.new{'r2'}
+  rs = [r1, r2]
+  as = []
+  r, obj = Ractor.select(*rs)
+  rs.delete(r)
+  as << obj
+  r, obj = Ractor.select(*rs)
+  as << obj
+  as.sort #=> ["r1", "r2"]
+}
+
+# Ractor.select from multiple ractors.
+assert_equal 30.times.map { 'ok' }.to_s, %q{
+  def test n
+    rs = (1..n).map do |i|
+      Ractor.new(i) do |i|
+        "r#{i}"
+      end
+    end
+    as = []
+    all_rs = rs.dup
+
+    n.times{
+      r, obj = Ractor.select(*rs)
+      as << [r, obj]
+      rs.delete(r)
+    }
+
+    if as.map{|r, o| r.object_id}.sort == all_rs.map{|r| r.object_id}.sort &&
+       as.map{|r, o| o}.sort == (1..n).map{|i| "r#{i}"}.sort
+      'ok'
+    else
+      'ng'
+    end
+  end
+
+  30.times.map{|i|
+    test i
+  }
+} unless ENV['RUN_OPTS'] =~ /--jit-min-calls=5/ # This always fails with --jit-wait --jit-min-calls=5
+
+# Exception for empty select
+assert_match /specify at least one ractor/, %q{
+  begin
+    Ractor.select
+  rescue ArgumentError => e
+    e.message
+  end
+}
+
+# Outgoing port of a ractor will be closed when the Ractor is terminated.
+assert_equal 'ok', %q{
+  r = Ractor.new do
+    'finish'
+  end
+
+  r.take
+  sleep 0.1 until r.inspect =~ /terminated/
+
+  begin
+    o = r.take
+  rescue Ractor::ClosedError
+    'ok'
+  else
+    "ng: #{o}"
+  end
+}
+
+# Raise Ractor::ClosedError when try to send into a terminated ractor
+assert_equal 'ok', %q{
+  r = Ractor.new do
+  end
+
+  r.take # closed
+  sleep 0.1 until r.inspect =~ /terminated/
+
+  begin
+    r.send(1)
+  rescue Ractor::ClosedError
+    'ok'
+  else
+    'ng'
+  end
+}
+
+# Raise Ractor::ClosedError when try to send into a closed actor
+assert_equal 'ok', %q{
+  r = Ractor.new { Ractor.receive }
+  r.close_incoming
+
+  begin
+    r.send(1)
+  rescue Ractor::ClosedError
+    'ok'
+  else
+    'ng'
+  end
+}
+
+# Raise Ractor::ClosedError when try to take from closed actor
+assert_equal 'ok', %q{
+  r = Ractor.new do
+    Ractor.yield 1
+    Ractor.receive
+  end
+
+  r.close_outgoing
+  begin
+    r.take
+  rescue Ractor::ClosedError
+    'ok'
+  else
+    'ng'
+  end
+}
+
+# Can mix with Thread#interrupt and Ractor#take [Bug #17366]
+assert_equal 'err', %q{
+  Ractor.new{
+    t = Thread.current
+    begin
+      Thread.new{ t.raise "err" }.join
+    rescue => e
+      e.message
+    end
+  }.take
+}
+
+# Killed Ractor's thread yields nil
+assert_equal 'nil', %q{
+  Ractor.new{
+    t = Thread.current
+    Thread.new{ t.kill }.join
+  }.take.inspect #=> nil
+}
+
+# Ractor.yield raises Ractor::ClosedError when outgoing port is closed.
+assert_equal 'ok', %q{
+  r = Ractor.new Ractor.current do |main|
+    Ractor.receive
+    main << true
+    Ractor.yield 1
+  end
+
+  r.close_outgoing
+  r << true
+  Ractor.receive
+
+  begin
+    r.take
+  rescue Ractor::ClosedError
+    'ok'
+  else
+    'ng'
+  end
+}
+
+# Raise Ractor::ClosedError when try to send into a ractor with closed incoming port
+assert_equal 'ok', %q{
+  r = Ractor.new { Ractor.receive }
+  r.close_incoming
+
+  begin
+    r.send(1)
+  rescue Ractor::ClosedError
+    'ok'
+  else
+    'ng'
+  end
+}
+
+# A ractor with closed incoming port still can send messages out
+assert_equal '[1, 2]', %q{
+  r = Ractor.new do
+    Ractor.yield 1
+    2
+  end
+  r.close_incoming
+
+  [r.take, r.take]
+}
+
+# Raise Ractor::ClosedError when try to take from a ractor with closed outgoing port
+assert_equal 'ok', %q{
+  r = Ractor.new do
+    Ractor.yield 1
+    Ractor.receive
+  end
+
+  sleep 0.01 # wait for Ractor.yield in r
+  r.close_outgoing
+  begin
+    r.take
+  rescue Ractor::ClosedError
+    'ok'
+  else
+    'ng'
+  end
+}
+
+# A ractor with closed outgoing port still can receive messages from incoming port
+assert_equal 'ok', %q{
+  r = Ractor.new do
+    Ractor.receive
+  end
+
+  r.close_outgoing
+  begin
+    r.send(1)
+  rescue Ractor::ClosedError
+    'ng'
+  else
+    'ok'
+  end
+}
+
+# a ractor with closed outgoing port should terminate
+assert_equal 'ok', %q{
+  Ractor.new do
+    close_outgoing
+  end
+
+  true until Ractor.count == 1
+  :ok
+}
+
+# multiple Ractors can receive (wait) from one Ractor
+assert_equal '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]', %q{
+  pipe = Ractor.new do
+    loop do
+      Ractor.yield Ractor.receive
+    end
+  end
+
+  rn = 10
+  rs = rn.times.map{|i|
+    Ractor.new pipe, i do |pipe, i|
+      msg = pipe.take
+      msg # ping-pong
+    end
+  }
+  rn.times{|i|
+    pipe << i
+  }
+  rn.times.map{
+    r, n = Ractor.select(*rs)
+    rs.delete r
+    n
+  }.sort
+}
+
+# Ractor.select also support multiple take, receive and yield
+assert_equal '[true, true, true]', %q{
+  RN = 10
+  CR = Ractor.current
+
+  rs = (1..RN).map{
+    Ractor.new do
+      CR.send 'send' + CR.take #=> 'sendyield'
+      'take'
+    end
+  }
+  received = []
+  take = []
+  yielded = []
+  until rs.empty?
+    r, v = Ractor.select(CR, *rs, yield_value: 'yield')
+    case r
+    when :receive
+      received << v
+    when :yield
+      yielded << v
+    else
+      take << v
+      rs.delete r
+    end
+  end
+  [received == ['sendyield']*RN, yielded == [nil]*RN, take == ['take']*RN]
+}
+
+# multiple Ractors can send to one Ractor
+assert_equal '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]', %q{
+  pipe = Ractor.new do
+    loop do
+      Ractor.yield Ractor.receive
+    end
+  end
+
+  rn = 10
+  rn.times.map{|i|
+    Ractor.new pipe, i do |pipe, i|
+      pipe << i
+    end
+  }
+  rn.times.map{
+    pipe.take
+  }.sort
+}
+
+# an exception in a Ractor will be re-raised at Ractor#receive
+assert_equal '[RuntimeError, "ok", true]', %q{
+  r = Ractor.new do
+    raise 'ok' # exception will be transferred receiver
+  end
+  begin
+    r.take
+  rescue Ractor::RemoteError => e
+    [e.cause.class,   #=> RuntimeError
+     e.cause.message, #=> 'ok'
+     e.ractor == r]   #=> true
+  end
+}
+
+# threads in a ractor will killed
+assert_equal '[:ok, :ok, :ok]', %q{
+  Ractor.new Ractor.current do |main|
+    q = Queue.new
+    Thread.new do
+    begin
+      q << true
+      loop{}
+    ensure
+      main << :ok
+    end
+    end
+
+    Thread.new do
+    begin
+      q << true
+      while true
+      end
+    ensure
+      main << :ok
+    end
+    end
+
+    Thread.new do
+    begin
+      q << true
+      sleep 1
+    ensure
+      main << :ok
+    end
+    end
+
+    # wait for the start of all threads
+    3.times{q.pop}
+  end
+
+  3.times.map{Ractor.receive}.inspect
+}
+
+# unshareable object are copied
+assert_equal 'false', %q{
+  obj = 'str'.dup
+  r = Ractor.new obj do |msg|
+    msg.object_id
+  end
+
+  obj.object_id == r.take
+}
+
+# To copy the object, now Marshal#dump is used
+assert_equal "allocator undefined for Thread", %q{
+  obj = Thread.new{}
+  begin
+    r = Ractor.new obj do |msg|
+      msg
+    end
+  rescue TypeError => e
+    e.message #=> no _dump_data is defined for class Thread
+  else
+    'ng'
+  end
+}
+
+# send shareable and unshareable objects
+assert_equal "ok", %q{
+  echo_ractor = Ractor.new do
+    loop do
+      v = Ractor.receive
+      Ractor.yield v
+    end
+  end
+
+  class C; end
+  module M; end
+  S = Struct.new(:a, :b, :c, :d)
+
+  shareable_objects = [
+    true,
+    false,
+    nil,
+    1,
+    1.1,    # Float
+    1+2r,   # Rational
+    3+4i,   # Complex
+    2**128, # Bignum
+    :sym,   # Symbol
+    'xyzzy'.to_sym, # dynamic symbol
+    'frozen'.freeze, # frozen String
+    /regexp/, # regexp literal
+    /reg{true}exp/.freeze, # frozen dregexp
+    [1, 2].freeze,   # frozen Array which only refers to shareable
+    {a: 1}.freeze,   # frozen Hash which only refers to shareable
+    [{a: 1}.freeze, 'str'.freeze].freeze, # nested frozen container
+    S.new(1, 2).freeze, # frozen Struct
+    S.new(1, 2, 3, 4).freeze, # frozen Struct
+    (1..2), # Range on Struct
+    #(1..),  # Range on Struct
+    #(..1),  # Range on Struct
+    C, # class
+    M, # module
+    Ractor.current, # Ractor
+  ]
+
+  unshareable_objects = [
+    'mutable str'.dup,
+    [:array],
+    {hash: true},
+    S.new(1, 2),
+    S.new(1, 2, 3, 4),
+    S.new("a", 2).freeze, # frozen, but refers to an unshareable object
+  ]
+
+  results = []
+
+  shareable_objects.map{|o|
+    echo_ractor << o
+    o2 = echo_ractor.take
+    results << "#{o} is copied" unless o.object_id == o2.object_id
+  }
+
+  unshareable_objects.map{|o|
+    echo_ractor << o
+    o2 = echo_ractor.take
+    results << "#{o.inspect} is not copied" if o.object_id == o2.object_id
+  }
+
+  if results.empty?
+    :ok
+  else
+    results.inspect
+  end
+}
+
+# frozen Objects are shareable
+assert_equal [false, true, false].inspect, %q{
+  class C
+    def initialize freeze
+      @a = 1
+      @b = :sym
+      @c = 'frozen_str'
+      @c.freeze if freeze
+      @d = true
+    end
+  end
+
+  def check obj1
+    obj2 = Ractor.new obj1 do |obj|
+      obj
+    end.take
+
+    obj1.object_id == obj2.object_id
+  end
+
+  results = []
+  results << check(C.new(true))         # false
+  results << check(C.new(true).freeze)  # true
+  results << check(C.new(false).freeze) # false
+}
+
+# move example2: String
+# touching moved object causes an error
+assert_equal 'hello world', %q{
+  # move
+  r = Ractor.new do
+    obj = Ractor.receive
+    obj << ' world'
+  end
+
+  str = 'hello'
+  r.send str, move: true
+  modified = r.take
+
+  begin
+    str << ' exception' # raise Ractor::MovedError
+  rescue Ractor::MovedError
+    modified #=> 'hello world'
+  else
+    raise 'unreachable'
+  end
+}
+
+# move example2: Array
+assert_equal '[0, 1]', %q{
+  r = Ractor.new do
+    ary = Ractor.receive
+    ary << 1
+  end
+
+  a1 = [0]
+  r.send a1, move: true
+  a2 = r.take
+  begin
+    a1 << 2 # raise Ractor::MovedError
+  rescue Ractor::MovedError
+    a2.inspect
+  end
+}
+
+# move with yield
+assert_equal 'hello', %q{
+  r = Ractor.new do
+    Thread.current.report_on_exception = false
+    obj = 'hello'
+    Ractor.yield obj, move: true
+    obj << 'world'
+  end
+
+  str = r.take
+  begin
+    r.take
+  rescue Ractor::RemoteError
+    str #=> "hello"
+  end
+}
+
+# Access to global-variables are prohibited
+assert_equal 'can not access global variables $gv from non-main Ractors', %q{
+  $gv = 1
+  r = Ractor.new do
+    $gv
+  end
+
+  begin
+    r.take
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# Access to global-variables are prohibited
+assert_equal 'can not access global variables $gv from non-main Ractors', %q{
+  r = Ractor.new do
+    $gv = 1
+  end
+
+  begin
+    r.take
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# $stdin,out,err is Ractor local, but shared fds
+assert_equal 'ok', %q{
+  r = Ractor.new do
+    [$stdin, $stdout, $stderr].map{|io|
+      [io.object_id, io.fileno]
+    }
+  end
+
+  [$stdin, $stdout, $stderr].zip(r.take){|io, (oid, fno)|
+    raise "should not be different object" if io.object_id == oid
+    raise "fd should be same" unless io.fileno == fno
+  }
+  'ok'
+}
+
+# $DEBUG, $VERBOSE are Ractor local
+assert_equal 'true', %q{
+  $DEBUG = true
+  $VERBOSE = true
+
+  def ractor_local_globals
+    /a(b)(c)d/ =~ 'abcd' # for $~
+    `echo foo` unless  /solaris/ =~ RUBY_PLATFORM
+
+    {
+     # ractor-local (derived from created ractor): debug
+     '$DEBUG' => $DEBUG,
+     '$-d' => $-d,
+
+     # ractor-local (derived from created ractor): verbose
+     '$VERBOSE' => $VERBOSE,
+     '$-w' => $-w,
+     '$-W' => $-W,
+     '$-v' => $-v,
+
+     # process-local (readonly): other commandline parameters
+     '$-p' => $-p,
+     '$-l' => $-l,
+     '$-a' => $-a,
+
+     # process-local (readonly): getpid
+     '$$'  => $$,
+
+     # thread local: process result
+     '$?'  => $?,
+
+     # scope local: match
+     '$~'  => $~.inspect,
+     '$&'  => $&,
+     '$`'  => $`,
+     '$\''  => $',
+     '$+'  => $+,
+     '$1'  => $1,
+
+     # scope local: last line
+     '$_' => $_,
+
+     # scope local: last backtrace
+     '$@' => $@,
+     '$!' => $!,
+
+     # ractor local: stdin, out, err
+     '$stdin'  => $stdin.inspect,
+     '$stdout' => $stdout.inspect,
+     '$stderr' => $stderr.inspect,
+    }
+  end
+
+  h = Ractor.new do
+    ractor_local_globals
+  end.take
+  ractor_local_globals == h #=> true
+}
+
+# selfs are different objects
+assert_equal 'false', %q{
+  r = Ractor.new do
+    self.object_id
+  end
+  r.take == self.object_id #=> false
+}
+
+# self is a Ractor instance
+assert_equal 'true', %q{
+  r = Ractor.new do
+    self.object_id
+  end
+  r.object_id == r.take #=> true
+}
+
+# given block Proc will be isolated, so can not access outer variables.
+assert_equal 'ArgumentError', %q{
+  begin
+    a = true
+    r = Ractor.new do
+      a
+    end
+  rescue => e
+    e.class
+  end
+}
+
+# ivar in shareable-objects are not allowed to access from non-main Ractor
+assert_equal 'can not access instance variables of classes/modules from non-main Ractors', %q{
+  class C
+    @iv = 'str'
+  end
+
+  r = Ractor.new do
+    class C
+      p @iv
+    end
+  end
+
+
+  begin
+    r.take
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# ivar in shareable-objects are not allowed to access from non-main Ractor
+assert_equal 'can not access instance variables of shareable objects from non-main Ractors', %q{
+  shared = Ractor.new{}
+  shared.instance_variable_set(:@iv, 'str')
+
+  r = Ractor.new shared do |shared|
+    p shared.instance_variable_get(:@iv)
+  end
+
+  begin
+    r.take
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# ivar in shareable-objects are not allowed to access from non-main Ractor, by @iv (get)
+assert_equal 'can not access instance variables of shareable objects from non-main Ractors', %q{
+  class Ractor
+    def setup
+      @foo = ''
+    end
+
+    def foo
+      @foo
+    end
+  end
+
+  shared = Ractor.new{}
+  shared.setup
+
+  r = Ractor.new shared do |shared|
+    p shared.foo
+  end
+
+  begin
+    r.take
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# ivar in shareable-objects are not allowed to access from non-main Ractor, by @iv (set)
+assert_equal 'can not access instance variables of shareable objects from non-main Ractors', %q{
+  class Ractor
+    def setup
+      @foo = ''
+    end
+  end
+
+  shared = Ractor.new{}
+
+  r = Ractor.new shared do |shared|
+    p shared.setup
+  end
+
+  begin
+    r.take
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# But a shareable object is frozen, it is allowed to access ivars from non-main Ractor
+assert_equal '11', %q{
+  [Object.new, [], ].map{|obj|
+    obj.instance_variable_set('@a', 1)
+    Ractor.make_shareable obj = obj.freeze
+
+    Ractor.new obj do |obj|
+      obj.instance_variable_get('@a')
+    end.take.to_s
+  }.join
+}
+
+# cvar in shareable-objects are not allowed to access from non-main Ractor
+assert_equal 'can not access class variables from non-main Ractors', %q{
+  class C
+    @@cv = 'str'
+  end
+
+  r = Ractor.new do
+    class C
+      p @@cv
+    end
+  end
+
+  begin
+    r.take
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# Getting non-shareable objects via constants by other Ractors is not allowed
+assert_equal 'can not access non-shareable objects in constant C::CONST by non-main Ractor.', %q{
+  class C
+    CONST = 'str'
+  end
+  r = Ractor.new do
+    C::CONST
+  end
+  begin
+    r.take
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# Setting non-shareable objects into constants by other Ractors is not allowed
+assert_equal 'can not set constants with non-shareable objects by non-main Ractors', %q{
+  class C
+  end
+  r = Ractor.new do
+    C::CONST = 'str'
+  end
+  begin
+    r.take
+  rescue Ractor::RemoteError => e
+    e.cause.message
+  end
+}
+
+# define_method is not allowed
+assert_equal "defined in a different Ractor", %q{
+  str = "foo"
+  define_method(:buggy){|i| str << "#{i}"}
+  begin
+    Ractor.new{buggy(10)}.take
+  rescue => e
+    e.cause.message
+  end
+}
+
+# Immutable Array and Hash are shareable, so it can be shared with constants
+assert_equal '[1000, 3]', %q{
+  A = Array.new(1000).freeze # [nil, ...]
+  H = {a: 1, b: 2, c: 3}.freeze
+
+  Ractor.new{ [A.size, H.size] }.take
+}
+
+# Ractor.count
+assert_equal '[1, 4, 3, 2, 1]', %q{
+  counts = []
+  counts << Ractor.count
+  ractors = (1..3).map { Ractor.new { Ractor.receive } }
+  counts << Ractor.count
+
+  ractors[0].send('End 0').take
+  sleep 0.1 until ractors[0].inspect =~ /terminated/
+  counts << Ractor.count
+
+  ractors[1].send('End 1').take
+  sleep 0.1 until ractors[1].inspect =~ /terminated/
+  counts << Ractor.count
+
+  ractors[2].send('End 2').take
+  sleep 0.1 until ractors[2].inspect =~ /terminated/
+  counts << Ractor.count
+
+  counts.inspect
+}
+
+# ObjectSpace.each_object can not handle unshareable objects with Ractors
+assert_equal '0', %q{
+  Ractor.new{
+    n = 0
+    ObjectSpace.each_object{|o| n += 1 unless Ractor.shareable?(o)}
+    n
+  }.take
+}
+
+# ObjectSpace._id2ref can not handle unshareable objects with Ractors
+assert_equal 'ok', %q{
+  s = 'hello'
+
+  Ractor.new s.object_id do |id ;s|
+    begin
+      s = ObjectSpace._id2ref(id)
+    rescue => e
+      :ok
+    end
+  end.take
+}
+
+# Ractor.make_shareable(obj)
+assert_equal 'true', %q{
+  class C
+    def initialize
+      @a = 'foo'
+      @b = 'bar'
+    end
+
+    def freeze
+      @c = [:freeze_called]
+      super
+    end
+
+    attr_reader :a, :b, :c
+  end
+  S = Struct.new(:s1, :s2)
+  str = "hello"
+  str.instance_variable_set("@iv", "hello")
+  /a/ =~ 'a'
+  m = $~
+  class N < Numeric
+    def /(other)
+      1
+    end
+  end
+  ary = []; ary << ary
+
+  a = [[1, ['2', '3']],
+       {Object.new => "hello"},
+       C.new,
+       S.new("x", "y"),
+       ("a".."b"),
+       str,
+       ary,             # cycle
+       /regexp/,
+       /#{'r'.upcase}/,
+       m,
+       Complex(N.new,0),
+       Rational(N.new,0),
+       true,
+       false,
+       nil,
+       1, 1.2, 1+3r, 1+4i, # Numeric
+  ]
+  Ractor.make_shareable(a)
+
+  # check all frozen
+  a.each{|o|
+    raise o.inspect unless o.frozen?
+
+    case o
+    when C
+      raise o.a.inspect unless o.a.frozen?
+      raise o.b.inspect unless o.b.frozen?
+      raise o.c.inspect unless o.c.frozen? && o.c == [:freeze_called]
+    when Rational
+      raise o.numerator.inspect unless o.numerator.frozen?
+    when Complex
+      raise o.real.inspect unless o.real.frozen?
+    when Array
+      if o[0] == 1
+        raise o[1][1].inspect unless o[1][1].frozen?
+      end
+    when Hash
+      o.each{|k, v|
+        raise k.inspect unless k.frozen?
+        raise v.inspect unless v.frozen?
+      }
+    end
+  }
+
+  Ractor.shareable?(a)
+}
+
+# Ractor.make_shareable(obj) doesn't freeze shareable objects
+assert_equal 'true', %q{
+  r = Ractor.new{}
+  Ractor.make_shareable(a = [r])
+  [a.frozen?, a[0].frozen?] == [true, false]
+}
+
+# Ractor.make_shareable(a_proc) makes a proc shareable.
+assert_equal 'true', %q{
+  a = [1, [2, 3], {a: "4"}]
+  pr = Proc.new do
+    a
+  end
+  Ractor.make_shareable(a) # referred value should be shareable
+  Ractor.make_shareable(pr)
+  Ractor.shareable?(pr)
+}
+
+# Ractor.shareable?(recursive_objects)
+assert_equal '[false, false]', %q{
+  y = []
+  x = [y, {}].freeze
+  y << x
+  y.freeze
+  [Ractor.shareable?(x), Ractor.shareable?(y)]
+}
+
+# Ractor.make_shareable(recursive_objects)
+assert_equal '[:ok, false, false]', %q{
+  o = Object.new
+  def o.freeze; raise; end
+  y = []
+  x = [y, o].freeze
+  y << x
+  y.freeze
+  [(Ractor.make_shareable(x) rescue :ok), Ractor.shareable?(x), Ractor.shareable?(y)]
+}
+
+# define_method() can invoke different Ractor's proc if the proc is shareable.
+assert_equal '1', %q{
+  class C
+    a = 1
+    define_method "foo", Ractor.make_shareable(Proc.new{ a })
+    a = 2
+  end
+
+  Ractor.new{ C.new.foo }.take
+}
+
+# Ractor.make_shareable(a_proc) makes a proc shareable.
+assert_equal 'can not make a Proc shareable because it accesses outer variables (a).', %q{
+  a = b = nil
+  pr = Proc.new do
+    c = b # assign to a is okay because c is block local variable
+          # reading b is okay
+    a = b # assign to a is not allowed #=> Ractor::Error
+  end
+
+  begin
+    Ractor.make_shareable(pr)
+  rescue => e
+    e.message
+  end
+}
+
+# Ractor deep copies frozen objects (ary)
+assert_equal '[true, false]', %q{
+  Ractor.new([[]].freeze) { |ary|
+    [ary.frozen?, ary.first.frozen? ]
+  }.take
+}
+
+# Ractor deep copies frozen objects (str)
+assert_equal '[true, false]', %q{
+  s = String.new.instance_eval { @x = []; freeze}
+  Ractor.new(s) { |s|
+    [s.frozen?, s.instance_variable_get(:@x).frozen?]
+  }.take
+}
+
+# Can not trap with not isolated Proc on non-main ractor
+assert_equal '[:ok, :ok]', %q{
+  a = []
+  Ractor.new{
+    trap(:INT){p :ok}
+  }.take
+  a << :ok
+
+  begin
+    Ractor.new{
+      s = 'str'
+      trap(:INT){p s}
+    }.take
+  rescue => Ractor::RemoteError
+    a << :ok
+  end
+}
+
+###
+### Synchronization tests
+###
+
+N = 100_000
+
+# fstring pool
+assert_equal "#{N}#{N}", %Q{
+  n = #{N}
+  2.times.map{
+    Ractor.new{
+      n.times{|i| -(i.to_s)}
+    }
+  }.map{|r| r.take}.join
+}
+
+# enc_table
+assert_equal "#{N/10}", %Q{
+  Ractor.new do
+    loop do
+    begin
+      Encoding.find("test-enc-#{rand(5_000)}").inspect
+    rescue ArgumentError => e
+    end
+    end
+  end
+
+  src = Encoding.find("UTF-8")
+  #{N/10}.times{|i|
+    src.replicate("test-enc-\#{i}")
+  }
+}
+
+# Generic ivtbl
+n = N/2
+assert_equal "#{n}#{n}", %Q{
+  2.times.map{
+    Ractor.new do
+      #{n}.times do
+        obj = ''
+        obj.instance_variable_set("@a", 1)
+        obj.instance_variable_set("@b", 1)
+        obj.instance_variable_set("@c", 1)
+        obj.instance_variable_defined?("@a")
+      end
+    end
+  }.map{|r| r.take}.join
+}
+
+end # if !ENV['GITHUB_WORKFLOW']

--- a/test/test_ractor.rb
+++ b/test/test_ractor.rb
@@ -3,6 +3,28 @@
 # - remove endless ranges
 # - wrap a rescue between `begin` `else` ~1246
 
+# Ractor.count
+assert_equal '[1, 4, 3, 2, 1]', %q{
+  counts = []
+  counts << Ractor.count
+  ractors = (1..3).map { Ractor.new { Ractor.receive } }
+  counts << Ractor.count
+
+  ractors[0].send('End 0').take
+  sleep 0.1 until ractors[0].inspect =~ /terminated/
+  counts << Ractor.count
+
+  ractors[1].send('End 1').take
+  sleep 0.1 until ractors[1].inspect =~ /terminated/
+  counts << Ractor.count
+
+  ractors[2].send('End 2').take
+  sleep 0.1 until ractors[2].inspect =~ /terminated/
+  counts << Ractor.count
+
+  counts.inspect
+}
+
 # Ractor.current returns a current ractor
 assert_equal 'Ractor', %q{
   Ractor.current.class
@@ -1002,28 +1024,6 @@ assert_equal '[1000, 3]', %q{
   H = {a: 1, b: 2, c: 3}.freeze
 
   Ractor.new{ [A.size, H.size] }.take
-}
-
-# Ractor.count
-assert_equal '[1, 4, 3, 2, 1]', %q{
-  counts = []
-  counts << Ractor.count
-  ractors = (1..3).map { Ractor.new { Ractor.receive } }
-  counts << Ractor.count
-
-  ractors[0].send('End 0').take
-  sleep 0.1 until ractors[0].inspect =~ /terminated/
-  counts << Ractor.count
-
-  ractors[1].send('End 1').take
-  sleep 0.1 until ractors[1].inspect =~ /terminated/
-  counts << Ractor.count
-
-  ractors[2].send('End 2').take
-  sleep 0.1 until ractors[2].inspect =~ /terminated/
-  counts << Ractor.count
-
-  counts.inspect
 }
 
 # ObjectSpace.each_object can not handle unshareable objects with Ractors


### PR DESCRIPTION
Goal: if it works with `Ractor`, it works with backport
Non-goal: if it fails with `Ractor` (e.g. attempt to access class variable), it fails with backport. These checks are not present with backport.
Limitations: uses `Thread`s instead of actual actors, so still subject to GIL and won't have the actual performance of `Ractor` (of course 😅)