### PR TITLE
Implement String#unpack1

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ itself, JRuby and Rubinius.
 
 #### String
   - `match?`
+  - `unpack1`
 
 #### FalseClass, Fixnum, Bignum, Float, NilClass, TrueClass
   - `dup`

--- a/lib/backports/2.4.0/string/unpack1.rb
+++ b/lib/backports/2.4.0/string/unpack1.rb
@@ -1,0 +1,7 @@
+unless String.method_defined? :unpack1
+  class String
+    def unpack1(fmt)
+      unpack(fmt)[0]
+    end
+  end
+end


### PR DESCRIPTION
This implements `String#unpack1` which was added first to Ruby 2.4.0 in https://bugs.ruby-lang.org/issues/12752