### PR TITLE
ruby-2.7: Symbol#end_with?

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ itself, JRuby and Rubinius.
 #### Enumerator
   - `produce` (class method)
 
+#### Symbol
+  - `end_with?`
+
 #### Time
   - `floor`, `ceil`
 

--- a/lib/backports/2.7.0/symbol.rb
+++ b/lib/backports/2.7.0/symbol.rb
@@ -1,0 +1,3 @@
+require 'backports/tools/require_relative_dir'
+
+Backports.require_relative_dir

--- a/lib/backports/2.7.0/symbol/end_with.rb
+++ b/lib/backports/2.7.0/symbol/end_with.rb
@@ -1,0 +1,9 @@
+require 'backports/1.8.7/string/end_with' unless String.method_defined? :end_with
+
+unless Symbol.method_defined?(:end_with?)
+  class Symbol
+    def end_with?(*suffixes)
+      to_s.end_with?(*suffixes)
+    end
+  end
+end


### PR DESCRIPTION
Backport `Symbol#end_with?` (available as of Ruby 2.7.0)