### PR TITLE
Fix String#end_with? guard clause in Symbol

### DIFF
--- a/lib/backports/2.7.0/symbol/end_with.rb
+++ b/lib/backports/2.7.0/symbol/end_with.rb
@@ -1,4 +1,4 @@
-require 'backports/1.8.7/string/end_with' unless String.method_defined? :end_with
+require 'backports/1.8.7/string/end_with' unless String.method_defined? :end_with?
 
 unless Symbol.method_defined?(:end_with?)
   class Symbol


### PR DESCRIPTION
Fixes minor typo introduced in https://github.com/marcandre/backports/pull/171
The issue isn't noticeable as `backports/1.8.7/string/end_with` has proper guard.