### PR TITLE
Quote the 3.0 to ensure it loads a 3.0.x Ruby

### DIFF
--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: [2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, head]
+        ruby: [2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', head]
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Without quotes, the 3.0 is truncated to 3 and it loads the most recent Ruby 3 release - at this point Ruby 3.1.  Adding quotes ensures that a Ruby 3.0.x is loaded, as intended.

This can be seen in the Actions screen:
<img width="1495" alt="Screen Shot 2022-01-26 at 5 33 50 PM" src="https://user-images.githubusercontent.com/421488/151275758-93e5d97f-e4a4-4dce-927b-3c92bbbc44d2.png">

