### PR TITLE
A few small fixes for rubyspecs

### DIFF
--- a/lib/backports/3.2.0/enumerator/product.rb
+++ b/lib/backports/3.2.0/enumerator/product.rb
@@ -1,12 +1,19 @@
 unless Enumerator.method_defined? :product
   if RUBY_VERSION >= '2.7'
     instance_eval <<-EOT, __FILE__, __LINE__ + 1
-      def Enumerator.product(*enums, **nil, &block)
+      def Enumerator.product(*enums, **kwargs, &block)
+        if kwargs && !kwargs.empty?
+          raise ArgumentError.new("unknown keywords: " + kwargs.keys.map(&:inspect).join(", "))
+        end
         Enumerator::Product.new(*enums).each(&block)
       end
     EOT
   else
     def Enumerator.product(*enums, &block)
+      kwargs = enums[-1]
+      if kwargs.kind_of?(Hash) && !kwargs.empty?
+        raise ArgumentError.new("unknown keywords: " + kwargs.keys.map(&:inspect).join(", "))
+      end
       Enumerator::Product.new(*enums).each(&block)
     end
   end
@@ -47,15 +54,17 @@ unless Enumerator.method_defined? :product
     def size
       total_size = 1
       @__enums.each do |enum|
+        return nil unless enum.respond_to?(:size)
         size = enum.size
-        return size if size == nil || size == Float::INFINITY
+        return size if size == nil || size == Float::INFINITY || size == -Float::INFINITY
+        return nil unless size.kind_of?(Integer)
         total_size *= size
       end
       total_size
     end
 
     def rewind
-      @__enums.reverse_each do |enum|
+      @__enums.each do |enum|
         enum.rewind if enum.respond_to?(:rewind)
       end
       self

--- a/lib/backports/3.2.0/enumerator/product.rb
+++ b/lib/backports/3.2.0/enumerator/product.rb
@@ -3,7 +3,7 @@ unless Enumerator.method_defined? :product
     instance_eval <<-EOT, __FILE__, __LINE__ + 1
       def Enumerator.product(*enums, **kwargs, &block)
         if kwargs && !kwargs.empty?
-          raise ArgumentError.new("unknown keywords: " + kwargs.keys.map(&:inspect).join(", "))
+          raise ArgumentError, "unknown keywords: #{kwargs.keys.map(&:inspect).join(", ")}"
         end
         Enumerator::Product.new(*enums).each(&block)
       end
@@ -11,7 +11,7 @@ unless Enumerator.method_defined? :product
   else
     def Enumerator.product(*enums, &block)
       kwargs = enums[-1]
-      if kwargs.kind_of?(Hash) && !kwargs.empty?
+      if kwargs.is_a?(Hash) && !kwargs.empty?
         raise ArgumentError.new("unknown keywords: " + kwargs.keys.map(&:inspect).join(", "))
       end
       Enumerator::Product.new(*enums).each(&block)
@@ -57,7 +57,7 @@ unless Enumerator.method_defined? :product
         return nil unless enum.respond_to?(:size)
         size = enum.size
         return size if size == nil || size == Float::INFINITY
-        return nil unless size.kind_of?(Integer)
+        return nil unless size.is_a?(Integer)
         total_size *= size
       end
       total_size

--- a/lib/backports/3.2.0/enumerator/product.rb
+++ b/lib/backports/3.2.0/enumerator/product.rb
@@ -3,7 +3,7 @@ unless Enumerator.method_defined? :product
     instance_eval <<-'EOT', __FILE__, __LINE__ + 1
       def Enumerator.product(*enums, **kwargs, &block)
         if kwargs && !kwargs.empty?
-          raise ArgumentError, "unknown keywords: #{kwargs.keys.map(&:inspect).join(", ")}"
+          raise ArgumentError, "unknown keywords: #{kwargs.keys.map(&:inspect).join(', ')}"
         end
         Enumerator::Product.new(*enums).each(&block)
       end
@@ -12,7 +12,7 @@ unless Enumerator.method_defined? :product
     def Enumerator.product(*enums, &block)
       kwargs = enums[-1]
       if kwargs.is_a?(Hash) && !kwargs.empty?
-        raise ArgumentError, "unknown keywords: #{kwargs.keys.map(&:inspect).join(", ")}"
+        raise ArgumentError, "unknown keywords: #{kwargs.keys.map(&:inspect).join(', ')}"
       end
       Enumerator::Product.new(*enums).each(&block)
     end

--- a/lib/backports/3.2.0/enumerator/product.rb
+++ b/lib/backports/3.2.0/enumerator/product.rb
@@ -12,7 +12,7 @@ unless Enumerator.method_defined? :product
     def Enumerator.product(*enums, &block)
       kwargs = enums[-1]
       if kwargs.is_a?(Hash) && !kwargs.empty?
-        raise ArgumentError.new("unknown keywords: " + kwargs.keys.map(&:inspect).join(", "))
+        raise ArgumentError, "unknown keywords: #{kwargs.keys.map(&:inspect).join(", ")}"
       end
       Enumerator::Product.new(*enums).each(&block)
     end

--- a/lib/backports/3.2.0/enumerator/product.rb
+++ b/lib/backports/3.2.0/enumerator/product.rb
@@ -1,6 +1,6 @@
 unless Enumerator.method_defined? :product
   if RUBY_VERSION >= '2.7'
-    instance_eval <<-EOT, __FILE__, __LINE__ + 1
+    instance_eval <<-'EOT', __FILE__, __LINE__ + 1
       def Enumerator.product(*enums, **kwargs, &block)
         if kwargs && !kwargs.empty?
           raise ArgumentError, "unknown keywords: #{kwargs.keys.map(&:inspect).join(", ")}"

--- a/lib/backports/3.2.0/enumerator/product.rb
+++ b/lib/backports/3.2.0/enumerator/product.rb
@@ -56,7 +56,7 @@ unless Enumerator.method_defined? :product
       @__enums.each do |enum|
         return nil unless enum.respond_to?(:size)
         size = enum.size
-        return size if size == nil || size == Float::INFINITY || size == -Float::INFINITY
+        return size if size == nil || size == Float::INFINITY
         return nil unless size.kind_of?(Integer)
         total_size *= size
       end


### PR DESCRIPTION
Fixes 10 cases from rubyspec:

* Size error cases
* Enumerator.product rejects kwargs by name
* Product#rewind rewinds in "direct order", not reverse

JRuby is using this impl for now, and this brings the failure count for the `Enumerator::Product` specs down to 10 (43 total, 20 failures without this PR).