### PR TITLE
fix: inverted test for singleton_class? existence

### DIFF
--- a/lib/backports/2.1.0/module/singleton_class.rb
+++ b/lib/backports/2.1.0/module/singleton_class.rb
@@ -1,4 +1,4 @@
-if Module.method_defined? :singleton_class?
+unless Module.method_defined? :singleton_class?
   class Module
     def singleton_class?
       # Hacky...


### PR DESCRIPTION
It is overloading the method when it *was* implemented instead of when it was not.